### PR TITLE
fix 1.删除识别记录时同步删除该记录对应的转移黑名单;2.重新识别同一记录后，修改历史识别记录时间，防止重新识别后在最新历史记录中看不到

### DIFF
--- a/app/helper/db_helper.py
+++ b/app/helper/db_helper.py
@@ -212,6 +212,19 @@ class DbHelper:
                                                      TRANSFERHISTORY.DEST_FILENAME == dest_filename).count()
         return True if ret > 0 else False
 
+    def update_transfer_history_date(self, source_path, source_filename, dest_path, dest_filename, date):
+        """
+        更新历史转移记录时间
+        """
+        self._db.query(TRANSFERHISTORY).filter(TRANSFERHISTORY.SOURCE_PATH == source_path,
+                                                     TRANSFERHISTORY.SOURCE_FILENAME == source_filename,
+                                                     TRANSFERHISTORY.DEST_PATH == dest_path,
+                                                     TRANSFERHISTORY.DEST_FILENAME == dest_filename).update(
+            {
+                "DATE": date
+            }
+        )
+
     @DbPersist(_db)
     def insert_transfer_history(self, in_from: Enum, rmt_mode: RmtMode, in_path, out_path, dest, media_info):
         """
@@ -235,10 +248,12 @@ class DbHelper:
             dest_filename = ""
             season_episode = media_info.get_season_string()
         title = media_info.title
+        timestr = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))
         if self.is_transfer_history_exists(source_path, source_filename, dest_path, dest_filename):
+            # 更新历史转移记录的时间
+            self.update_transfer_history_date(source_path, source_filename, dest_path, dest_filename, timestr)
             return
         dest = dest or ""
-        timestr = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))
         self._db.insert(
             TRANSFERHISTORY(
                 MODE=str(rmt_mode.value),
@@ -453,6 +468,14 @@ class DbHelper:
             self._db.insert(TRANSFERBLACKLIST(
                 PATH=os.path.normpath(path)
             ))
+
+    @DbPersist(_db)
+    def delete_transfer_blacklist(self, path):
+        """
+        删除黑名单记录
+        """
+        self._db.query(TRANSFERBLACKLIST).filter(TRANSFERBLACKLIST.PATH == str(path)).delete()
+        self._db.query(SYNCHISTORY).filter(SYNCHISTORY.PATH == str(path)).delete()
 
     @DbPersist(_db)
     def truncate_transfer_blacklist(self, ):

--- a/web/action.py
+++ b/web/action.py
@@ -841,6 +841,8 @@ class WebAction:
                 # 根据flag删除文件
                 source_path = paths[0].SOURCE_PATH
                 source_filename = paths[0].SOURCE_FILENAME
+                # 删除该识别记录对应的转移记录
+                self.dbhelper.delete_transfer_blacklist("%s/%s" % (source_path, source_filename))
                 dest = paths[0].DEST
                 dest_path = paths[0].DEST_PATH
                 dest_filename = paths[0].DEST_FILENAME


### PR DESCRIPTION
今早把很久之前的记录删除了，然后重新下载，识别同步后，只有一集转移成功，其他都显示已经转移，所以加了删除识别记录的同时删除转移黑名单；
之前也遇到过很久之前识别的，没删除识别记录重新手动识别，在历史识别最新里面看不到数据，所以加了重新识别更新历史识别记录数据，体验更好点。

![image](https://user-images.githubusercontent.com/54088512/218629842-31dba351-42d8-4e10-9a52-e4dbe2909f68.png)