### PR TITLE
fix qbitorrent API: tag为空list时报参数错误，导致自动删种失败

### DIFF
--- a/app/downloader/client/qbittorrent.py
+++ b/app/downloader/client/qbittorrent.py
@@ -96,7 +96,7 @@ class Qbittorrent(_IDownloadClient):
         if not self.qbc:
             return [], True
         try:
-            if len(tag) == 0:
+            if tag is not None and len(tag) == 0:
                 tag = None
             torrents = self.qbc.torrents_info(torrent_hashes=ids, status_filter=status, tag=tag)
             if self.is_ver_less_4_4():

--- a/app/downloader/client/qbittorrent.py
+++ b/app/downloader/client/qbittorrent.py
@@ -96,6 +96,8 @@ class Qbittorrent(_IDownloadClient):
         if not self.qbc:
             return [], True
         try:
+            if len(tag) == 0:
+                tag = None
             torrents = self.qbc.torrents_info(torrent_hashes=ids, status_filter=status, tag=tag)
             if self.is_ver_less_4_4():
                 torrents = self.filter_torrent_by_tag(torrents, tag=tag)


### PR DESCRIPTION
`pt_monitor_only = false`，自动删种的`onlynastool`设置也为`false`时，
`qbittorrent.py` 里面的请求:
```python
line 99: 
torrents = self.qbc.torrents_info(torrent_hashes=ids, status_filter=status, tag=tag)
```

此时`tag`为空列表，api 会报参数错误，导致自动删种失败。

```
 Callstack:
nas-tools  | Traceback (most recent call last):
nas-tools  |   File "/nas-tools/app/downloader/client/qbittorrent.py", line 99, in get_torrents
nas-tools  |     torrents = self.qbc.torrents_info(torrent_hashes=ids, status_filter=status, tag=tag)
nas-tools  |   File "/nas-tools/third_party/qbittorrent-api/qbittorrentapi/decorators.py", line 119, in wrapper
nas-tools  |     return func(client, *args, **kwargs)
nas-tools  |   File "/nas-tools/third_party/qbittorrent-api/qbittorrentapi/decorators.py", line 164, in wrapper
nas-tools  |     response = func(client, *args, **kwargs)
nas-tools  |   File "/nas-tools/third_party/qbittorrent-api/qbittorrentapi/decorators.py", line 92, in wrapper
nas-tools  |     return func(client, *args, **kwargs)
nas-tools  |   File "/nas-tools/third_party/qbittorrent-api/qbittorrentapi/torrents.py", line 1663, in torrents_info
nas-tools  |     return self._post(_name=APINames.Torrents, _method="info", data=data, **kwargs)
nas-tools  |   File "/nas-tools/third_party/qbittorrent-api/qbittorrentapi/request.py", line 350, in _post
nas-tools  |     return self._request_manager(
nas-tools  |   File "/nas-tools/third_party/qbittorrent-api/qbittorrentapi/request.py", line 401, in _request_manager
nas-tools  |     return self._request(**kwargs)
nas-tools  |   File "/nas-tools/third_party/qbittorrent-api/qbittorrentapi/request.py", line 463, in _request
nas-tools  |     self._handle_error_responses(data, params, response)
nas-tools  |   File "/nas-tools/third_party/qbittorrent-api/qbittorrentapi/request.py", line 634, in _handle_error_responses
nas-tools  |     raise MissingRequiredParameters400Error()
nas-tools  | qbittorrentapi.exceptions.MissingRequiredParameters400Error
```