### PR TITLE
fix bug

### DIFF
--- a/web/action.py
+++ b/web/action.py
@@ -3490,17 +3490,20 @@ class WebAction:
                         and filter_season not in torrent_filter.get("season"):
                     torrent_filter["season"].append(filter_season)
             else:
+                exist_flag = False
                 # 是否已存在
                 if item.TMDBID:
-                    exist_flag = MediaServer().check_item_exists(
-                        mtype=mtype,
-                        title=item.TITLE,
-                        year=item.YEAR,
-                        tmdbid=item.TMDBID,
-                        season=int(filter_season.replace("S", "")) if filter_season else None
-                    )
-                else:
-                    exist_flag = False
+                    try:
+                        exist_flag = MediaServer().check_item_exists(
+                            mtype=mtype,
+                            title=item.TITLE,
+                            year=item.YEAR,
+                            tmdbid=item.TMDBID,
+                            season=int(filter_season.replace("S", "")) if filter_season else None
+                        )
+                    # One Piece S01-S21 E01-E1028 1999 1080p WEB-DL H.264 -@OPFansMaplesnow
+                    except:
+                        pass
                 SearchResults[title_string] = {
                     "key": item.ID,
                     "title": item.TITLE,


### PR DESCRIPTION
种子名称：One Piece S01-S21 E01-E1028 1999 1080p WEB-DL H.264 -@OPFansMaplesnow

报错信息：
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/flask/app.py", line 2528, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python3.10/site-packages/flask/app.py", line 1825, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python3.10/site-packages/flask_restx/api.py", line 674, in error_router
    return original_handler(e)
  File "/usr/lib/python3.10/site-packages/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python3.10/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/usr/lib/python3.10/site-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
  File "/nas-tools/web/main.py", line 249, in search
    res = WebAction().get_search_result()
  File "/nas-tools/web/action.py", line 3593, in get_search_result
    season=int(filter_season.replace("S", "")) if filter_season else None
ValueError: invalid literal for int() with base 10: '01-21'

