### PR TITLE
重命名相关问题

### DIFF
--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -1124,11 +1124,11 @@ class FileTransfer:
         episode_title = self.media.get_episode_title(media)
         # 此处使用独立对象，避免影响语言
         en_title = Media().get_tmdb_en_title(media)
-        return {
+        media_format_dict = {
             "title": StringUtils.clear_file_name(media.title),
-            "en_title": StringUtils.clear_file_name(en_title),
-            "original_name": StringUtils.clear_file_name(os.path.splitext(media.org_string or "")[0]),
-            "original_title": StringUtils.clear_file_name(media.original_title),
+            "en_title": StringUtils.clear_file_name(en_title, is_en=True),
+            "original_name": StringUtils.clear_file_name(os.path.splitext(media.org_string or "")[0], is_en=True),
+            "original_title": StringUtils.clear_file_name(media.original_title, is_en=True),
             "name": StringUtils.clear_file_name(media.get_name()),
             "year": media.year,
             "edition": media.get_edtion_string() or None,
@@ -1138,13 +1138,16 @@ class FileTransfer:
             "videoCodec": media.video_encode,
             "audioCodec": media.audio_encode,
             "tmdbid": media.tmdb_id,
-            "imdbid": media.imdb_id,
             "season": media.get_season_seq(),
             "episode": media.get_episode_seqs(),
             "episode_title": StringUtils.clear_file_name(episode_title),
             "season_episode": "%s%s" % (media.get_season_item(), media.get_episode_items()),
             "part": media.part
         }
+        for i in media_format_dict.keys():
+            if not media_format_dict[i]:
+                media_format_dict[i] = '\t'
+        return media_format_dict
 
     def get_moive_dest_path(self, media_info):
         """
@@ -1152,8 +1155,8 @@ class FileTransfer:
         :return: 电影目录、电影名称
         """
         format_dict = self.get_format_dict(media_info)
-        dir_name = re.sub(r"[-_\s.]*None", "", self._movie_dir_rmt_format.format(**format_dict))
-        file_name = re.sub(r"[-_\s.]*None", "", self._movie_file_rmt_format.format(**format_dict))
+        dir_name = re.sub(r"[-_\s.]*\t", "", self._movie_dir_rmt_format.format(**format_dict))
+        file_name = re.sub(r"[-_\s.]*\t", "", self._movie_file_rmt_format.format(**format_dict))
         return dir_name, file_name
 
     def get_tv_dest_path(self, media_info):
@@ -1162,9 +1165,9 @@ class FileTransfer:
         :return: 电视剧目录、季目录、集名称
         """
         format_dict = self.get_format_dict(media_info)
-        dir_name = re.sub(r"[-_\s.]*None", "", self._tv_dir_rmt_format.format(**format_dict))
-        season_name = re.sub(r"[-_\s.]*None", "", self._tv_season_rmt_format.format(**format_dict))
-        file_name = re.sub(r"[-_\s.]*None", "", self._tv_file_rmt_format.format(**format_dict))
+        dir_name = re.sub(r"[-_\s.]*\t", "", self._tv_dir_rmt_format.format(**format_dict))
+        season_name = re.sub(r"[-_\s.]*\t", "", self._tv_season_rmt_format.format(**format_dict))
+        file_name = re.sub(r"[-_\s.]*\t", "", self._tv_file_rmt_format.format(**format_dict))
         return dir_name, season_name, file_name
 
     def check_ignore(self, file_list):

--- a/app/utils/string_utils.py
+++ b/app/utils/string_utils.py
@@ -249,10 +249,13 @@ class StringUtils:
         return f"{scheme}://{netloc}"
 
     @staticmethod
-    def clear_file_name(name):
+    def clear_file_name(name, is_en=False):
         if not name:
             return None
-        return re.sub(r"[*?\\/\"<>~]", "", name, flags=re.IGNORECASE).replace(":", "：")
+        if not is_en:
+            return re.sub(r"[*?\\/\"<>~]", "", name, flags=re.IGNORECASE).replace(":", "：")
+        else:
+            return re.sub(r"[*?\\/\"<>~]", "", name, flags=re.IGNORECASE)
 
     @staticmethod
     def get_keyword_from_string(content):


### PR DESCRIPTION
解决 https://github.com/NAStool/nas-tools/issues/2692 中提到的两个关于识别重命名的问题
（与之前 https://github.com/NAStool/nas-tools/pull/3627 内容相同，由于上次流程不规范，没有新建一个分支提交。新建分支后重新提交，如有打扰请海涵）

1. 解决文件名中含有"None"时重命名不显示的问题（思路：考虑到涉及信息点应该不会存在制表符，故用制表符代替空值 `None`，后续改为对制表符进行处理）；
2. 解决使用"en_title"等英文信息重命名时，英文半角冒号(:)被替换为中文全角冒号(：)的问题（思路：加入 `is_en` 输入，默认为假，如为真则不替换中文冒号）。

第一次提交PR，可能水平和经验不太够，不知是否有更优解决方案，还请大佬指教。
已使用修改后代码进行过一次整库识别重命名测试，没有出现其他问题。