### PR TITLE
修复剧集NFO文件中 tmdbid 错误

### DIFF
--- a/app/media/scraper.py
+++ b/app/media/scraper.py
@@ -188,7 +188,6 @@ class Scraper:
         self.__save_nfo(doc, os.path.join(out_path, "season.nfo"))
 
     def __gen_tv_episode_nfo_file(self,
-                                  tmdbid,
                                   seasoninfo: dict,
                                   scraper_tv_nfo,
                                   season: int,
@@ -197,7 +196,6 @@ class Scraper:
                                   file_name):
         """
         生成电视剧集的NFO描述文件
-        :param tmdbid: TMDB ID
         :param seasoninfo: TMDB元数据
         :param scraper_tv_nfo: 刮削配置
         :param season: 季号
@@ -220,11 +218,11 @@ class Scraper:
             # 添加时间
             DomUtils.add_node(doc, root, "dateadded", time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())))
             # TMDBID
-            uniqueid = DomUtils.add_node(doc, root, "uniqueid", tmdbid or "")
+            uniqueid = DomUtils.add_node(doc, root, "uniqueid", episode_detail.get("id") or "")
             uniqueid.setAttribute("type", "tmdb")
             uniqueid.setAttribute("default", "true")
             # tmdbid
-            DomUtils.add_node(doc, root, "tmdbid", tmdbid or "")
+            DomUtils.add_node(doc, root, "tmdbid", episode_detail.get("id") or "")
             # 标题
             DomUtils.add_node(doc, root, "title", episode_detail.get("name") or "第 %s 集" % episode)
             # 简介
@@ -449,8 +447,7 @@ class Scraper:
                         seasoninfo = self.media.get_tmdb_tv_season_detail(tmdbid=media.tmdb_id,
                                                                           season=int(media.get_season_seq()))
                         if seasoninfo:
-                            self.__gen_tv_episode_nfo_file(tmdbid=media.tmdb_id,
-                                                           seasoninfo=seasoninfo,
+                            self.__gen_tv_episode_nfo_file(seasoninfo=seasoninfo,
                                                            scraper_tv_nfo=scraper_tv_nfo,
                                                            season=int(media.get_season_seq()),
                                                            episode=int(media.get_episode_seq()),


### PR DESCRIPTION
修复 #3666 。首先感谢大佬百忙之中做出的修改 https://github.com/NAStool/nas-tools/commit/916220cba9b31d03867b5b8a7477d606f8880d22


看了一下，以前是将每一季的 `id` 写入了集 NFO 文件。修改后是将整个剧的 `tmdbid` 传入 `__gen_tv_episode_nfo_file` 函数中，写入了集 NFO 文件。

我发现传入的 `seasoninfo` 中包含所需参数（如下，`'id'` 的值即为每一集的 `tmdbid`）。所得到的 `episode_detail` 中的 `id` 即为每一集的 tmdbid，遂略微改动了一下。

```
	{
		'air_date': '2023-03-02',
		'episode_number': 14,
		'id': 4227557,
		'name': '第 14 集',
		'overview': '',
		'production_code': '',
		'runtime': None,
		'season_number': 6,
		'show_id': 71728,
		'still_path': '/6Chf0oALoXjwEwnC5kkMi28waQi.jpg',
		'vote_average': 8.0,
		'vote_count': 1,
		'crew': [],
		'guest_stars': [{
			'character': 'Jim McAllister',
			'credit_id': '6367af6ac048a9007e8f7402',
			'order': 862,
			'adult': False,
			'gender': 2,
			'id': 39125,
			'known_for_department': 'Acting',
			'name': 'Will Sasso',
			'original_name': 'Will Sasso',
			'popularity': 15.609,
			'profile_path': '/4F8p9Dg32WJl12ras7CzQzLFy2i.jpg'
		}, {
			'character': 'Audrey McAllister',
			'credit_id': '636e78deca4f6700821136c1',
			'order': 863,
			'adult': False,
			'gender': 1,
			'id': 2138774,
			'known_for_department': 'Acting',
			'name': 'Rachel Bay Jones',
			'original_name': 'Rachel Bay Jones',
			'popularity': 12.86,
			'profile_path': '/tpRPZq95tM9v1GOzDYtxPu4isPq.jpg'
		}]
	}
```