### PR TITLE
考虑增加TMDB英文支持

### DIFF
--- a/app/media/media.py
+++ b/app/media/media.py
@@ -51,7 +51,6 @@ class Media:
                     self.tmdb.domain = app.get("tmdb_domain")
                 self.tmdb.cache = True
                 self.tmdb.api_key = app.get('rmt_tmdbkey')
-                self.tmdb.language = 'zh'
                 self.tmdb.proxies = Config().get_proxies()
                 self.tmdb.debug = True
                 self.search = Search()
@@ -156,8 +155,7 @@ class Media:
             return None
         if language:
             self.tmdb.language = language
-        else:
-            self.tmdb.language = 'zh-CN'
+
         # TMDB检索
         info = {}
         if search_type == MediaType.MOVIE:
@@ -506,8 +504,7 @@ class Media:
             return None
         if language:
             self.tmdb.language = language
-        else:
-            self.tmdb.language = 'zh-CN'
+
         if mtype == MediaType.MOVIE:
             tmdb_info = self.__get_tmdb_movie_detail(tmdbid, append_to_response)
             if tmdb_info:


### PR DESCRIPTION
#3494 #3002 

由于TMDB api本身已经可以通过读取环境变量的方式设置语言，且在没有设置环境变量的情况下默认中文([这里](https://github.com/NAStool/nas-tools/blob/38ab92f9368b8f2cbd6b03006fd46d7e816647ec/app/media/tmdbv3api/tmdb.py#L33))。可以考虑在media.py中删除硬编码的方式设置‘zh-CN’到tmdb.language。

通过本地测试，设置language 为en-US工作正常，可以满足海报和影片路径为英文的需要。


