### PR TITLE
站点数据刷新时间默认配置

### DIFF
--- a/check_config.py
+++ b/check_config.py
@@ -203,6 +203,14 @@ def update_config():
     except Exception as e:
         ExceptionUtils.exception_traceback(e)
 
+    # 站点数据刷新时间默认配置
+    try:
+        if "ptrefresh_date_cron" not in _config['pt']:
+            _config['pt']['ptrefresh_date_cron'] = '6'
+            overwrite_cofig = True
+    except Exception as e:
+        ExceptionUtils.exception_traceback(e)
+
     # 重写配置文件
     if overwrite_cofig:
         Config().save_config(_config)


### PR DESCRIPTION
如果pt.ptrefresh_date_cron不存在,给他设置为6
如果pt.ptrefresh_date_cron存在,无论值是什么,都不处理