### PR TITLE
fix bug #3729 默认订阅检索站点

### DIFF
--- a/app/utils/types.py
+++ b/app/utils/types.py
@@ -146,7 +146,10 @@ class SystemConfigKey(Enum):
     DefaultDownloader = "DefaultDownloader"
     # 默认下载设置
     DefaultDownloadSetting = "DefaultDownloadSetting"
-
+    # 默认电影订阅检索站点
+    DefaultMovieSitesSetting = "DefaultMovieSitesSetting"
+    # 默认电视剧订阅检索站点
+    DefaultTVSitesSetting = "DefaultTVSitesSetting"
 
 # 处理进度Key字典
 class ProgressKey(Enum):

--- a/web/action.py
+++ b/web/action.py
@@ -1384,11 +1384,11 @@ class WebAction:
             "type") in MovieTypes else MediaType.TV
 
         # 查询是否已设置默认订阅检索站点
-        default_sites = SystemConfig().get_system_config(
-            key=SystemConfigKey.DefaultMovieSitesSetting if mtype in MovieTypes else SystemConfigKey.DefaultTVSitesSetting)
-        if default_sites:
-            rss_sites = rss_sites or default_sites.get('rss') or []
-            search_sites = search_sites or default_sites.get('search') or []
+        if not rssid:
+            default_sites = SystemConfig().get_system_config(
+                key=SystemConfigKey.DefaultMovieSitesSetting if mtype in MovieTypes else SystemConfigKey.DefaultTVSitesSetting)
+            rss_sites = rss_sites or default_sites.get('rss') if default_sites else []
+            search_sites = search_sites or default_sites.get('search') if default_sites else []
 
         media_info = None
         if isinstance(season, list):

--- a/web/action.py
+++ b/web/action.py
@@ -1386,8 +1386,9 @@ class WebAction:
         # 查询是否已设置默认订阅检索站点
         default_sites = SystemConfig().get_system_config(
             key=SystemConfigKey.DefaultMovieSitesSetting if mtype in MovieTypes else SystemConfigKey.DefaultTVSitesSetting)
-        rss_sites = rss_sites or default_sites.get('rss') or []
-        search_sites = search_sites or default_sites.get('search') or []
+        if default_sites:
+            rss_sites = rss_sites or default_sites.get('rss') or []
+            search_sites = search_sites or default_sites.get('search') or []
 
         media_info = None
         if isinstance(season, list):

--- a/web/action.py
+++ b/web/action.py
@@ -216,7 +216,9 @@ class WebAction:
             "get_downloaders": self.__get_downloaders,
             "test_downloader": self.__test_downloader,
             "get_indexer_statistics": self.__get_indexer_statistics,
-            "media_path_scrap": self.__media_path_scrap
+            "media_path_scrap": self.__media_path_scrap,
+            "add_default_sites": self.__add_default_sites,
+            "get_default_sites": self.__get_default_sites
         }
 
     def action(self, cmd, data=None):
@@ -1380,6 +1382,13 @@ class WebAction:
         page = data.get("page")
         mtype = MediaType.MOVIE if data.get(
             "type") in MovieTypes else MediaType.TV
+
+        # 查询是否已设置默认订阅检索站点
+        default_sites = SystemConfig().get_system_config(
+            key=SystemConfigKey.DefaultMovieSitesSetting if mtype in MovieTypes else SystemConfigKey.DefaultTVSitesSetting)
+        rss_sites = rss_sites or default_sites.get('rss') or []
+        search_sites = search_sites or default_sites.get('search') or []
+
         media_info = None
         if isinstance(season, list):
             code = 0
@@ -4810,3 +4819,33 @@ class WebAction:
         """
         # 强制刷新站点数据,并发送站点统计的消息
         SiteUserInfo().refresh_pt_date_now()
+
+    @staticmethod
+    def __add_default_sites(data):
+        """
+        添加订阅|搜索默认站点
+        """
+        mtype = data.get("mtype")
+        rss_sites = data.get("rss_sites")
+        search_sites = data.get("search_sites")
+
+        # 保存默认站点
+        SystemConfig().set_system_config(
+            key=SystemConfigKey.DefaultMovieSitesSetting if mtype in MovieTypes else SystemConfigKey.DefaultTVSitesSetting,
+            value={
+                "rss": rss_sites,
+                "search": search_sites
+            })
+        return {"code": 0}
+
+    @staticmethod
+    def __get_default_sites(data):
+        """
+        添加订阅|搜索默认站点
+        """
+        mtype = data.get("mtype")
+
+        # 保存默认站点
+        default_sites = SystemConfig().get_system_config(
+            key=SystemConfigKey.DefaultMovieSitesSetting if mtype in MovieTypes else SystemConfigKey.DefaultTVSitesSetting)
+        return {"code": 0, "data": default_sites}

--- a/web/backend/search_torrents.py
+++ b/web/backend/search_torrents.py
@@ -329,6 +329,7 @@ def search_media_by_message(input_str, in_from: SearchType, user_id, user_name=N
             # 保存识别信息到临时结果中，由于消息长度限制只取前8条
             SEARCH_MEDIA_CACHE[user_id] = []
             for meta_info in medias[:8]:
+                # 合并站点和下载设置信息
                 meta_info.rss_sites = rss_sites
                 meta_info.search_sites = search_sites
                 meta_info.set_download_info(download_setting=download_setting)

--- a/web/backend/search_torrents.py
+++ b/web/backend/search_torrents.py
@@ -2,6 +2,7 @@ import os.path
 import re
 
 import log
+from app.conf import SystemConfig
 from app.downloader import Downloader
 from app.helper import DbHelper, ProgressHelper
 from app.indexer import Indexer
@@ -11,7 +12,7 @@ from app.searcher import Searcher
 from app.sites import Sites
 from app.subscribe import Subscribe
 from app.utils import StringUtils, Torrent
-from app.utils.types import SearchType, IndexerType, ProgressKey
+from app.utils.types import SearchType, IndexerType, ProgressKey, SystemConfigKey, MovieTypes
 from config import Config
 from web.backend.web_utils import WebUtils
 
@@ -328,9 +329,11 @@ def search_media_by_message(input_str, in_from: SearchType, user_id, user_name=N
             # 保存识别信息到临时结果中，由于消息长度限制只取前8条
             SEARCH_MEDIA_CACHE[user_id] = []
             for meta_info in medias[:8]:
-                # 合并站点和下载设置信息
-                meta_info.rss_sites = rss_sites
-                meta_info.search_sites = search_sites
+                default_sites = SystemConfig().get_system_config(
+                    key=SystemConfigKey.DefaultMovieSitesSetting if meta_info.type in MovieTypes else SystemConfigKey.DefaultTVSitesSetting)
+                # 合并站点和下载设置信息，没从搜索词中提取出站点则读取默认配置
+                meta_info.rss_sites = rss_sites or default_sites.get('rss') if default_sites else []
+                meta_info.search_sites = search_sites or default_sites.get('search') if default_sites else []
                 meta_info.set_download_info(download_setting=download_setting)
                 SEARCH_MEDIA_CACHE[user_id].append(meta_info)
 

--- a/web/backend/search_torrents.py
+++ b/web/backend/search_torrents.py
@@ -329,11 +329,8 @@ def search_media_by_message(input_str, in_from: SearchType, user_id, user_name=N
             # 保存识别信息到临时结果中，由于消息长度限制只取前8条
             SEARCH_MEDIA_CACHE[user_id] = []
             for meta_info in medias[:8]:
-                default_sites = SystemConfig().get_system_config(
-                    key=SystemConfigKey.DefaultMovieSitesSetting if meta_info.type in MovieTypes else SystemConfigKey.DefaultTVSitesSetting)
-                # 合并站点和下载设置信息，没从搜索词中提取出站点则读取默认配置
-                meta_info.rss_sites = rss_sites or default_sites.get('rss') if default_sites else []
-                meta_info.search_sites = search_sites or default_sites.get('search') if default_sites else []
+                meta_info.rss_sites = rss_sites
+                meta_info.search_sites = search_sites
                 meta_info.set_download_info(download_setting=download_setting)
                 SEARCH_MEDIA_CACHE[user_id].append(meta_info)
 
@@ -365,6 +362,12 @@ def search_media_by_message(input_str, in_from: SearchType, user_id, user_name=N
                                    user_id=user_id,
                                    user_name=user_name)
                 else:
+                    default_sites = SystemConfig().get_system_config(
+                         key=SystemConfigKey.DefaultMovieSitesSetting if meta_info.type in MovieTypes else SystemConfigKey.DefaultTVSitesSetting)
+                    # 合并站点和下载设置信息，没从搜索词中提取出站点则读取默认配置
+                    meta_info.rss_sites = rss_sites or default_sites.get('rss') if default_sites else []
+                    meta_info.search_sites = search_sites or default_sites.get('search') if default_sites else []
+              
                     # 添加订阅
                     __rss_media(in_from=in_from,
                                 media_info=media_info,

--- a/web/templates/navigation.html
+++ b/web/templates/navigation.html
@@ -343,6 +343,44 @@
     </div>
   </div>
 </div>
+<div class="modal modal-blur fade" id="modal-default-sites" tabindex="-1" role="dialog" aria-hidden="true"
+     data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">默认站点</h5>
+                <input type="hidden" id="default_sites_rss_type">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"
+                        id="default_sites_close_btn"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row rss_sites_container" id="default_rss_sites_div">
+                    <div class="mb-3">
+                        <div class="btn-list">
+                            <label class="form-label">订阅站点</label>
+                            <a href="javascript:void(0)" class="ms-auto"
+                               onclick="select_btn_SelectALL(this, 'default_rss_sites')">全选</a>
+                        </div>
+                        <div class="form-selectgroup" id="default_rss_sites_group"></div>
+                    </div>
+                </div>
+                <div class="row rss_sites_container" id="default_rss_search_sites_div">
+                    <div class="mb-3">
+                        <div class="btn-list">
+                            <label class="form-label">搜索站点</label>
+                            <a href="javascript:void(0)" class="ms-auto"
+                               onclick="select_btn_SelectALL(this, 'default_search_sites')">全选</a>
+                        </div>
+                        <div class="form-selectgroup" id="default_rss_search_sites_group"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button onclick="save_default_sites()" id="default_sites_save_btn" class="btn btn-primary">确定</button>
+            </div>
+        </div>
+    </div>
+</div>
 <!-- 手动订阅 -->
 <div class="modal modal-blur fade" id="modal-manual-rss" tabindex="-1" role="dialog" aria-hidden="true"
      data-bs-backdrop="static" data-bs-keyboard="false">
@@ -1457,6 +1495,63 @@
     $("[name='rss_add_btn']").show();
     $("#rss_delete_btn").hide();
     $("#modal-manual-rss").modal('show');
+  }
+
+  // 显示默认站点页面
+  function show_default_site_modal(mtype) {
+    refresh_rsssites_select("default_rss_sites_group", "default_rss_sites", false);
+    refresh_searchsites_select("default_rss_search_sites_group", "default_search_sites", false);
+
+    // 查询已保存配置
+    ajax_post("get_default_sites", {mtype:mtype}, function (ret) {
+      if (ret.code === 0) {
+        if (ret.data.rss.length === 0) {
+          select_SelectALL(false, 'default_rss_sites');
+        } else {
+          select_SelectPart(ret.data.rss, 'default_rss_sites')
+        }
+        if (ret.data.search.length === 0) {
+          select_SelectALL(false, 'default_search_sites');
+        } else {
+          select_SelectPart(ret.data.search, 'default_search_sites')
+        }
+      } else {
+        select_SelectALL(false, "default_rss_sites");
+        select_SelectALL(false, "default_search_sites");
+      }
+    });
+
+    if (mtype === "TV") {
+      $("#default_sites_rss_type").val("TV");
+    } else if (mtype === "MOV") {
+      $("#default_sites_rss_type").val("MOV");
+    }
+
+    $("#modal-default-sites").modal('show');
+  }
+
+  // 保存默认站点
+  function save_default_sites() {
+    const mtype = $("#default_sites_rss_type").val();
+    //订阅站点
+    let default_rss_sites = select_GetSelectedVAL("default_rss_sites");
+    //搜索站点
+    let default_search_sites = select_GetSelectedVAL("default_search_sites");
+
+    const data = {
+      "mtype": mtype,
+      "rss_sites": default_rss_sites,
+      "search_sites": default_search_sites
+    };
+
+    $("#modal-default-sites").modal("hide");
+    ajax_post("add_default_sites", data, function (ret) {
+      if (ret.code === 0) {
+        show_success_modal("设置默认站点成功！");
+      } else {
+        show_fail_modal(`设置默认站点失败：${ret.msg}！`);
+      }
+    });
   }
 
   // 显示编辑订阅

--- a/web/templates/rss/movie_rss.html
+++ b/web/templates/rss/movie_rss.html
@@ -10,6 +10,13 @@
       </div>
       <div class="col-auto ms-auto d-print-none">
         <div class="btn-list">
+          <a href="javascript:show_default_site_modal('MOV')" class="btn btn-primary d-none d-sm-inline-block">
+            {{ SVG.server_2() }}
+            默认站点
+          </a>
+          <a href="javascript:show_default_site_modal('MOV')" class="btn btn-primary d-sm-none btn-icon">
+            {{ SVG.server_2() }}
+          </a>
           <a href="javascript:show_add_rss_media_modal('MOV')" class="btn btn-primary d-none d-sm-inline-block">
             {{ SVG.plus() }}
             新增订阅

--- a/web/templates/rss/tv_rss.html
+++ b/web/templates/rss/tv_rss.html
@@ -10,6 +10,13 @@
       </div>
       <div class="col-auto ms-auto d-print-none">
         <div class="btn-list">
+          <a href="javascript:show_default_site_modal('TV')" class="btn btn-primary d-none d-sm-inline-block">
+            {{ SVG.server_2() }}
+            默认站点
+          </a>
+          <a href="javascript:show_default_site_modal('TV')" class="btn btn-primary d-sm-none btn-icon">
+            {{ SVG.server_2() }}
+          </a>
           <a href="javascript:show_add_rss_media_modal('TV')" class="btn btn-primary d-none d-sm-inline-block">
             {{ SVG.plus() }}
             新增订阅


### PR DESCRIPTION
1.电影订阅、电视剧订阅页面可分别设置电影默认订阅、搜索站点，电视剧默认订阅、搜索站点
2.探索页面直接点红心订阅时，检查是否设置默认订阅搜索站点，如有则直接填充设置，如无则走以前逻辑全部订阅检索
3.交互时，如未从交互内容中读取站点信息，则检查检查是否设置默认订阅搜索站点，如有则直接填充设置，如无则走以前逻辑全部订阅检索