### PR TITLE
CookieCloud数据同步时,使用domain域名的最后两级作为判断站点的唯一依据

### DIFF
--- a/app/sites/sites.py
+++ b/app/sites/sites.py
@@ -136,6 +136,15 @@ class Sites:
             return {}
         return ret_sites
 
+    def get_sites_by_suffix(self, suffix):
+        """
+        根据url的后缀获取站点配置
+        """
+        for key in self._siteByUrls:
+            if key.endswith(suffix):
+                return self._siteByUrls[key]
+        return {}
+
     def get_site_dict(self,
                       rss=False,
                       brush=False,


### PR DESCRIPTION
CookieCloud数据同步时,使用domain域名的最后两级作为判断站点的唯一依据