### PR TITLE
fix 修复非root用户首次启动后无法自动更新

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -91,6 +91,12 @@ echo "以PUID=${PUID}，PGID=${PGID}的身份启动程序..."
 chown -R "${PUID}":"${PGID}" $(ls -A | grep -vw -E '.git|.github')
 mkdir -p /.pm2 /.local
 chown -R "${PUID}":"${PGID}" /config /.pm2 /etc/hosts /usr/lib/chromium /.local
+# 避免 issue #3816，减少 chown 操作
+chown "${PUID}":"${PGID}" "${WORKDIR}"
+if [ "$(stat -c %u .git)":"$(stat -c %g .git)" != "${PUID}":"${PGID}" ]; then
+  find .git ! -user "${PUID}" -a ! -group "${PGID}" -exec chown "${PUID}":"${PGID}" {} \;
+  find .github ! -user "${PUID}" -a ! -group "${PGID}" -exec chown "${PUID}":"${PGID}" {} \;
+fi
 export PATH=${PATH}:/usr/lib/chromium
 
 # 掩码设置


### PR DESCRIPTION
运行环境：v3.0.5 docker版本，PUID=1026，PGID=100，关闭自动更新

初次启动并登录后，日志输出fatal错误

> ...
> 2023-03-22 01:54:33,033	INFO: 已注册事件：download.fail<function Webhook.send at 0x7f95d52a60e0>
> 2023-03-22 01:54:33,033	INFO: 已注册事件：libraryfile.deleted<function Webhook.send at 0x7f95d52a60e0>
> 2023-03-22 01:54:33,034	INFO: 加载插件：<class 'app.plugins.modules.speedlimiter.SpeedLimiter'>
> 2023-03-22 01:54:33,035	INFO: 加载插件：<class 'app.plugins.modules.torrentremover.TorrentRemover'>
> 2023-03-22 01:54:33,035	INFO: 加载插件：<class 'app.plugins.modules.libraryscraper.LibraryScraper'>
>  * Serving Flask app 'web.main'
>  * Debug mode: on
> fatal: detected dubious ownership in repository at '/nas-tools'
> To add an exception for this directory, call:
> 	git config --global --add safe.directory /nas-tools


接着点击右上角更新，日志输出如下（版本未更新成功）：

> ...
> error: could not lock config file //.gitconfig: Permission denied
> error: could not lock config file //.gitconfig: Permission denied
> fatal: detected dubious ownership in repository at '/nas-tools'
> To add an exception for this directory, call:
> 	git config --global --add safe.directory /nas-tools
> fatal: detected dubious ownership in repository at '/nas-tools'
> To add an exception for this directory, call:
> 	git config --global --add safe.directory /nas-tools
> fatal: detected dubious ownership in repository at '/nas-tools'
> To add an exception for this directory, call:
> 	git config --global --add safe.directory /nas-tools
> fatal: detected dubious ownership in repository at '/nas-tools'
> To add an exception for this directory, call:
> 	git config --global --add safe.directory /nas-tools
> WARNING: The directory '/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
> ...

此时进入容器查看权限发现 nas-tools .git .github 文件夹所属用户为 root。

============================

尝试修复此问题，同时避免再次出现 issue #3816 的问题：
1. 首先修正文件夹/nas-tools的权限，只针对文件夹操作
2. 检测 .git 文件夹权限是否正确，修复时使用 find 命令查找执行

经此修复后，理论上.git目录权限仅在初次运行、或修改了 PGID PUID 环境变量时才会修改。

修改后在线更新成功，输出如下：

> ...
> From https://github.com/NAStool/nas-tools
>  * branch            master     -> FETCH_HEAD
>  + 2715f71...714f390 master     -> origin/master  (forced update)
> HEAD is now at 714f390 Merge pull request #3931 from NAStool/dev
> ...
