### PR TITLE
给饼图标题一个固定宽度

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -180,3 +180,8 @@ body, .page {
         margin-right: unset!important;
     }
 }
+#chart-recent-upload-title,#chart-recent-download-title{
+    width: 250px;
+    display: inline-block;
+    text-align: center;
+}


### PR DESCRIPTION
给饼图标题一个固定宽度,防止按钮位置乱跑
# before
https://user-images.githubusercontent.com/31763582/226947064-dbc181e4-1ea3-4bdb-a9c1-6aee75ceabe8.mp4
# after
https://user-images.githubusercontent.com/31763582/226947580-28c74c7d-54fa-4ced-bd05-e01325bb4ac4.mp4



