### PR TITLE
过滤规则组默认折叠隐藏

### DIFF
--- a/web/templates/setting/filterrule.html
+++ b/web/templates/setting/filterrule.html
@@ -71,7 +71,7 @@
                 </a>
               </div>
             </div>
-            <div class="card-body p-2" id="div_group{{ RuleGroup.id }}">
+            <div class="card-body p-2 collapse" id="div_group{{ RuleGroup.id }}">
               <div class="row row-cards">
                 {% if RuleGroup.rules %}
                   {% for Rule in RuleGroup.rules %}


### PR DESCRIPTION
打开过滤规则页面或刷新后，所有已创建规则组默认折叠隐藏，简化便利用户打开页面后寻找目标规则组的操作。
默认折叠隐藏的话只需要找到目标规则组，展开，修改。