### PR TITLE
fix tr id

### DIFF
--- a/app/brushtask.py
+++ b/app/brushtask.py
@@ -300,7 +300,7 @@ class BrushTask(object):
                     continue
                 # 被手动从下载器删除的种子列表
                 remove_torrent_ids = list(
-                    set(torrent_ids).difference(set([torrent.get("hash") for torrent in torrents])))
+                    set(torrent_ids).difference(set([(torrent.get("hash") if downloader_type == 'qbittorrent' else str(torrent.id)) for torrent in torrents])))
                 # 完成的种子
                 for torrent in torrents:
                     torrent_info = self.__get_torrent_dict(downloader_type=downloader_type,
@@ -339,7 +339,7 @@ class BrushTask(object):
                     continue
                 # 更新手动从下载器删除的种子列表
                 remove_torrent_ids = list(
-                    set(remove_torrent_ids).difference(set([torrent.get("hash") for torrent in torrents])))
+                    set(remove_torrent_ids).difference(set([(torrent.get("hash") if downloader_type == 'qbittorrent' else str(torrent.id)) for torrent in torrents])))
                 # 下载中的种子
                 for torrent in torrents:
                     torrent_info = self.__get_torrent_dict(downloader_type=downloader_type,


### PR DESCRIPTION
修复 tr id 取 id 值,而不是像 qb 取 hash 值. 2.9 老版本是这样的判断的.

导致刷流任务被删除,而tr里的下载任务没有被删除,tr下载的任务一直增加.
日志信息提示 “这些下载任务在下载器中不存在，将删除任务记录”