### PR TITLE
为左侧的导航栏增加滚动功能，避免展开功能多的时候显示不全

### DIFF
--- a/web/static/components/layout/navbar/index.js
+++ b/web/static/components/layout/navbar/index.js
@@ -240,11 +240,11 @@ export class LayoutNavbar extends CustomElement {
       <div class="container-fluid">
         <div class="offcanvas offcanvas-start d-flex lit-navbar-canvas shadow" tabindex="-1" id="litLayoutNavbar">
           <div class="d-flex flex-row flex-grow-1 lit-navbar-hide-scrollbar">
-            <div class="d-flex flex-column flex-grow-1">
+            <div class="d-flex flex-column flex-grow-1 vh-100">
               <h1 class="mt-3" style="text-align:center;">
                 <img src="../static/img/logo/logo-blue.png" alt="NAStool" class="lit-navbar-logo">
               </h1>
-              <div class="accordion px-2 py-2 flex-grow-1">
+              <div class="accordion px-2 py-2 flex-grow-1 scroll-y">
                 ${this.navbar_list.map((item, index) => ( html`
                   ${item.list?.length > 0
                   ? html`


### PR DESCRIPTION
为左侧的导航栏增加滚动功能，避免展开功能多的时候显示不全，在pc和app下均已测试。

pc效果
![QQ截图20230328104243](https://user-images.githubusercontent.com/17189297/228121037-c2e61566-3897-40d6-b2a8-e2e9695f68e3.png)

app效果
![QQ截图20230328113439](https://user-images.githubusercontent.com/17189297/228121176-08be93cf-78b8-4035-b650-900f7761331c.png)
