### PR TITLE
fix 订阅历史重新订阅获取到总集数错误、CF优选插件增加自定义参数

### DIFF
--- a/app/subscribe.py
+++ b/app/subscribe.py
@@ -344,7 +344,7 @@ class Subscribe:
                                              tmdbid=rss[0].TMDBID,
                                              image=media.get_poster_image(),
                                              desc=media.overview,
-                                             total=total if total else rss[0].TOTAL,
+                                             total=total,
                                              start=rss[0].CURRENT_EP)
             # 删除订阅
             self.dbhelper.delete_rss_tv(rssid=rssid)


### PR DESCRIPTION
吞噬星空S04，前几天tmdb有3集，然后今天更新了第三集显示订阅完成。
之后我发现tmdb又更新到了6集，我于是在订阅历史重新订阅。但是会把之前已经完成的三集放到总集数那里。导致各种清理缓存还是直接订阅完成。


这里完成订阅如果该电视剧之前设置了总集数可以放入订阅历史，没有的话应该不需要把之前订阅获取到的tmdb集数放在历史，防止上述情况发生。