### PR TITLE
增强回调接口安全性

### DIFF
--- a/app/message/client/slack.py
+++ b/app/message/client/slack.py
@@ -32,7 +32,9 @@ class Slack(_IMessageClient):
         self.init_config()
 
     def init_config(self):
-        self._ds_url = "http://127.0.0.1:%s/slack" % self._config.get_config("app").get("web_port")
+        _web_port = self._config.get_config("app").get("web_port")
+        _api_key = self._config.get_config("security").get("api_key")
+        self._ds_url = "http://127.0.0.1:%s/slack?apikey=%s" % (_web_port, _api_key)
         if self._client_config:
             try:
                 slack_app = App(token=self._client_config.get("bot_token"))

--- a/app/message/client/telegram.py
+++ b/app/message/client/telegram.py
@@ -27,11 +27,13 @@ class Telegram(_IMessageClient):
     _client_config = {}
     _interactive = False
     _enabled = True
+    _api_key = None
 
     def __init__(self, config):
         self._client_config = config
         self._interactive = config.get("interactive")
         self._domain = Config().get_domain()
+        self._api_key = Config().get_config("security").get("api_key")
         if self._domain and self._domain.endswith("/"):
             self._domain = self._domain[:-1]
         self.init_config()
@@ -51,7 +53,7 @@ class Telegram(_IMessageClient):
             if self._telegram_token and self._telegram_chat_id:
                 if self._webhook:
                     if self._domain:
-                        self._webhook_url = "%s/telegram" % self._domain
+                        self._webhook_url = "%s/telegram?apikey=%s" % (self._domain, self._api_key)
                         self.__set_bot_webhook()
                     if self._message_proxy_event:
                         self._message_proxy_event.set()
@@ -300,7 +302,7 @@ class Telegram(_IMessageClient):
             _config = Config()
             web_port = _config.get_config("app").get("web_port")
             sc_url = "https://api.telegram.org/bot%s/getUpdates?" % self._telegram_token
-            ds_url = "http://127.0.0.1:%s/telegram" % web_port
+            ds_url = "http://127.0.0.1:%s/telegram?apikey=%s" % (web_port, self._api_key)
             if not self._enabled:
                 log.info("Telegram消息接收服务已停止")
                 break

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -244,6 +244,8 @@ security:
     ipv6: ::/0
   # 【API认证密钥】：用于Jellyseerr、Overseerr中Authorization认证以及非客户端类的API调用
   api_key:
+  # 【是否验证apikey】：新安装时默认开启，开启时需要在回调地址中传递api密钥进行验证。
+  check_apikey: True
 
 # 【实验室】
 laboratory:

--- a/initializer.py
+++ b/initializer.py
@@ -83,7 +83,7 @@ def update_config():
 
     # API密钥初始化
     if not _config.get("security", {}).get("api_key"):
-        _config['security']['api_key'] = StringUtils.generate_random_str()
+        _config['security']['api_key'] = StringUtils.generate_random_str(32)
         overwrite_cofig = True
 
     # 字幕兼容旧配置

--- a/web/main.py
+++ b/web/main.py
@@ -1191,6 +1191,7 @@ def wechat():
 
 # Plex Webhook
 @App.route('/plex', methods=['POST'])
+@require_auth(force=False)
 def plex_webhook():
     if not SecurityHelper().check_mediaserver_ip(request.remote_addr):
         log.warn(f"非法IP地址的媒体服务器消息通知：{request.remote_addr}")
@@ -1207,6 +1208,7 @@ def plex_webhook():
 
 # Jellyfin Webhook
 @App.route('/jellyfin', methods=['POST'])
+@require_auth(force=False)
 def jellyfin_webhook():
     if not SecurityHelper().check_mediaserver_ip(request.remote_addr):
         log.warn(f"非法IP地址的媒体服务器消息通知：{request.remote_addr}")
@@ -1221,8 +1223,9 @@ def jellyfin_webhook():
     return 'Ok'
 
 
-@App.route('/emby', methods=['POST'])
 # Emby Webhook
+@App.route('/emby', methods=['POST'])
+@require_auth(force=False)
 def emby_webhook():
     if not SecurityHelper().check_mediaserver_ip(request.remote_addr):
         log.warn(f"非法IP地址的媒体服务器消息通知：{request.remote_addr}")
@@ -1238,7 +1241,8 @@ def emby_webhook():
 
 
 # Telegram消息响应
-@App.route('/telegram', methods=['POST', 'GET'])
+@App.route('/telegram', methods=['POST'])
+@require_auth(force=False)
 def telegram():
     """
     {
@@ -1301,7 +1305,8 @@ def telegram():
 
 
 # Synology Chat消息响应
-@App.route('/synology', methods=['POST', 'GET'])
+@App.route('/synology', methods=['POST'])
+@require_auth(force=False)
 def synology():
     """
     token: bot token
@@ -1339,6 +1344,7 @@ def synology():
 
 # Slack消息响应
 @App.route('/slack', methods=['POST'])
+@require_auth(force=False)
 def slack():
     """
     # 消息
@@ -1471,7 +1477,7 @@ def slack():
 
 
 # Jellyseerr Overseerr订阅接口
-@App.route('/subscribe', methods=['POST', 'GET'])
+@App.route('/subscribe', methods=['POST'])
 @require_auth
 def subscribe():
     """

--- a/web/security.py
+++ b/web/security.py
@@ -27,7 +27,7 @@ def require_auth(func=None, force=True):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not must_apikey and \
+        if not force and \
                 not Config().get_config("security").get("check_apikey"):
             return func(*args, **kwargs)
         auth = request.headers.get("Authorization")

--- a/web/security.py
+++ b/web/security.py
@@ -4,7 +4,7 @@ import hashlib
 import hmac
 import json
 import os
-from functools import wraps
+from functools import wraps, partial
 
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
@@ -17,16 +17,28 @@ from app.utils import TokenCache
 from config import Config
 
 
-def require_auth(func):
+def require_auth(func=None, force=True):
     """
     API安全认证
+    force 是否强制检查apikey，为False时，会检查 check_apikey 配置值
     """
+    if func is None:
+        return partial(require_auth, force=force)
 
     @wraps(func)
     def wrapper(*args, **kwargs):
+        if not must_apikey and \
+                not Config().get_config("security").get("check_apikey"):
+            return func(*args, **kwargs)
         auth = request.headers.get("Authorization")
         if auth:
             auth = str(auth).split()[-1]
+            if auth == Config().get_config("security").get("api_key"):
+                return func(*args, **kwargs)
+        # 允许使用在api后面拼接 ?apikey=xxx 的方式进行验证
+        # 从query中获取apikey
+        auth = request.args.get("apikey")
+        if auth:
             if auth == Config().get_config("security").get("api_key"):
                 return func(*args, **kwargs)
         return {

--- a/web/security.py
+++ b/web/security.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import json
 import os
+import log
 from functools import wraps, partial
 
 from Crypto.Cipher import AES
@@ -35,12 +36,14 @@ def require_auth(func=None, force=True):
             auth = str(auth).split()[-1]
             if auth == Config().get_config("security").get("api_key"):
                 return func(*args, **kwargs)
+        log.debug(f"【Security】{func.__name__} 认证检查")
         # 允许使用在api后面拼接 ?apikey=xxx 的方式进行验证
         # 从query中获取apikey
         auth = request.args.get("apikey")
         if auth:
             if auth == Config().get_config("security").get("api_key"):
                 return func(*args, **kwargs)
+        log.warn(f"【Security】{func.__name__} 认证未通过，请检查API Key")
         return {
             "code": 401,
             "success": False,

--- a/web/templates/setting/basic.html
+++ b/web/templates/setting/basic.html
@@ -567,6 +567,20 @@
                 </div>
               </div>
             </div>
+            <div class="row">
+              <div class="col-xl">
+                  <div class="mb-3">
+                      <label class="form-check form-switch">
+                          <input class="form-check-input" type="checkbox" id="security.check_apikey"
+                                {% if Config.security.check_apikey %}checked{% endif %}>
+                          <span class="form-check-label">验证API密钥
+                              <span class="form-help" title="启用后，需要在原来的NasTools API地址后面拼接 ?apikey=xxx ，xxx 为API密钥；例如Emby回调接口由原来的 http://nastools:3000/emby 改为 http://nastools:3000/emby?apikey=xxx。受影响的接口有：plex、jellyfin、emby、telegram、synology、slack"
+                                    data-bs-toggle="tooltip">?</span>
+                          </span>
+                      </label>
+                  </div>
+              </div>
+            </div>
           </div>
           <div class="card-footer">
             <div class="row align-items-center">


### PR DESCRIPTION
apikey的参数通过query传递，使用方式是在原有的回调接口地址后面拼接 ?apikey=xxx 。该方式不需要其他服务端进行适配。

其他服务调用NasTools的回调接口时使用的都是POST方式，因为传递的数据量可能会超出GET方式的限制和可能的安全性问题，所以各个服务端基本也不会使用GET方式进行回调传参，没有什么兼容性问题。
唯一就是微信回调时可能会使用GET方法，可能会存在问题，同时也因为微信传递的消息本来就有加密，所以微信的回调就不验证apikey。

增加开关的目的是在于老版本自动更新后，如果没有及时为各个回调地址加上apikey时，原有的一套系统会无法工作。所以用户可以根据需要，手动开启。
新安装的用户则通过默认配置文件的方式，默认开启该选项。