### PR TITLE
支持Emby/Jellyfin自定义播放页面地址

### DIFF
--- a/app/conf/moduleconf.py
+++ b/app/conf/moduleconf.py
@@ -637,6 +637,14 @@ class ModuleConf(object):
                     "tooltip": "在Emby设置->高级->API密钥处生成，注意不要复制到了应用名称",
                     "type": "text",
                     "placeholder": ""
+                },
+                "play_host": {
+                    "id": "emby.play_host",
+                    "required": False,
+                    "title": "媒体播放地址",
+                    "tooltip": "配置播放设备的访问地址，如为https则需要增加https://前缀",
+                    "type": "text",
+                    "placeholder": "http://127.0.0.1:8096"
                 }
             }
         },
@@ -661,6 +669,14 @@ class ModuleConf(object):
                     "tooltip": "在Jellyfin设置->高级->API密钥处生成",
                     "type": "text",
                     "placeholder": ""
+                },
+                "play_host": {
+                    "id": "jellyfin.play_host",
+                    "required": False,
+                    "title": "媒体播放地址",
+                    "tooltip": "配置播放设备的访问地址，如为https则需要增加https://前缀",
+                    "type": "text",
+                    "placeholder": "http://127.0.0.1:8096"
                 }
             }
         },

--- a/app/mediaserver/client/emby.py
+++ b/app/mediaserver/client/emby.py
@@ -22,6 +22,7 @@ class Emby(_IMediaClient):
     _serverid = None
     _apikey = None
     _host = None
+    _play_host = None
     _user = None
     _libraries = []
 
@@ -40,6 +41,14 @@ class Emby(_IMediaClient):
                     self._host = "http://" + self._host
                 if not self._host.endswith('/'):
                     self._host = self._host + "/"
+            self._play_host = self._client_config.get('play_host')
+            if not self._play_host:
+                self._play_host = self._host
+            else:
+                if not self._play_host.startswith('http'):
+                    self._play_host = "http://" + self._play_host
+                if not self._play_host.endswith('/'):
+                    self._play_host = self._play_host + "/"
             self._apikey = self._client_config.get('api_key')
             if self._host and self._apikey:
                 self._libraries = self.__get_emby_librarys()
@@ -513,7 +522,7 @@ class Emby(_IMediaClient):
         拼装媒体播放链接
         :param item_id: 媒体的的ID
         """
-        return f"{self._host}web/index.html#!/item?id={item_id}&context=home&serverId={self._serverid}"
+        return f"{self._play_host}web/index.html#!/item?id={item_id}&context=home&serverId={self._serverid}"
 
     def get_items(self, parent):
         """

--- a/app/mediaserver/client/jellyfin.py
+++ b/app/mediaserver/client/jellyfin.py
@@ -20,6 +20,7 @@ class Jellyfin(_IMediaClient):
     _serverid = None
     _apikey = None
     _host = None
+    _play_host = None
     _user = None
     _libraries = []
 
@@ -38,6 +39,14 @@ class Jellyfin(_IMediaClient):
                     self._host = "http://" + self._host
                 if not self._host.endswith('/'):
                     self._host = self._host + "/"
+            self._play_host = self._client_config.get('play_host')
+            if not self._play_host:
+                self._play_host = self._host
+            else:
+                if not self._play_host.startswith('http'):
+                    self._play_host = "http://" + self._play_host
+                if not self._play_host.endswith('/'):
+                    self._play_host = self._play_host + "/"
             self._apikey = self._client_config.get('api_key')
             if self._host and self._apikey:
                 self._user = self.get_admin_user()
@@ -467,7 +476,7 @@ class Jellyfin(_IMediaClient):
         拼装媒体播放链接
         :param item_id: 媒体的的ID
         """
-        return f"{self._host}web/index.html#!/details?id={item_id}&serverId={self._serverid}"
+        return f"{self._play_host}web/index.html#!/details?id={item_id}&serverId={self._serverid}"
 
     def get_playing_sessions(self):
         """

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -104,6 +104,8 @@ emby:
   host: http://127.0.0.1:8096
   # 【Emby ApiKey】：在Emby设置->高级->API密钥处生成，注意不要复制到了应用名称
   api_key:
+  # 【Emby媒体播放地址和端口】：播放设备的访问地址，注意区分http和https，http时可以不加http://，https时必须加https://
+  play_host: http://127.0.0.1:8096
 
 # 配置Jellyfin服务器信息
 jellyfin:
@@ -111,6 +113,8 @@ jellyfin:
   host: http://127.0.0.1:8096
   # 【Jellyfin ApiKey】：在Jellyfin设置->高级->API密钥处生成
   api_key:
+  # 【Jellyfin媒体播放地址和端口】：播放设备的访问地址，注意区分http和https，http时可以不加http://，https时必须加https://
+  play_host: http://127.0.0.1:8096
 
 # 配置Plex服务器信息
 plex:


### PR DESCRIPTION
作者最新的版本新增了Emby/Jellyfin跳转播放页面的功能
但使用的是媒体服务器地址

这对docker环境、公网访问等场景不是太友好

此提交在媒体服务器的配置部分增加了play_host参数（非必须，默认取host）
在跳转播放页面时使用此配置