### PR TITLE
打开数据统计页面默认不刷新数据

### DIFF
--- a/app/sites/site_userinfo.py
+++ b/app/sites/site_userinfo.py
@@ -261,7 +261,8 @@ class SiteUserInfo(object):
         with lock:
 
             if not force \
-                    and not specify_sites:
+                    and not specify_sites \
+                    and self._last_update_time:
                 return
 
             if specify_sites \

--- a/app/sites/site_userinfo.py
+++ b/app/sites/site_userinfo.py
@@ -261,9 +261,7 @@ class SiteUserInfo(object):
         with lock:
 
             if not force \
-                    and not specify_sites \
-                    and self._last_update_time \
-                    and (datetime.now() - self._last_update_time).seconds < 6 * 3600:
+                    and not specify_sites:
                 return
 
             if specify_sites \


### PR DESCRIPTION
打开数据统计页面默认不刷新数据
设置了定时更新，后台更新数据了，打开数据统计页面直接拉取数据库数据就行
如果在数据统计页面想查看最新数据，就手动点击quanbu全部强制刷新或者单个站点刷新就行
![image](https://user-images.githubusercontent.com/54088512/228997046-68b96352-c78d-4dcf-8822-8e22f5dd90d0.png)

不然站点多，现在距离上次刷新大于6个小时的话，打开数据统计页面太慢了--