### PR TITLE
v3.1.3

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -214,7 +214,7 @@ jobs:
   Create-release_Send-message:
     permissions: write-all
     runs-on: ubuntu-latest
-    needs: [Windows-build, Linux-build, Mac-build]
+    needs: [Windows-build, Linux-build-amd64, Linux-build-arm64, Linux-build-amd64-musl, Linux-build-arm64-musl, Mac-build]
     steps:
     - uses: actions/checkout@v2
     - name: Release version

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-APP_VERSION = 'v3.1.2'
+APP_VERSION = 'v3.1.3'


### PR DESCRIPTION
• 新增插件市场，安装了的插件才会加载和运行。
• 豆瓣同步功能移植为了插件。
• 新增豆瓣榜单订阅插件，可配合rsshub实现豆瓣榜单自动添加订阅。
• 新增了插件相关的API。
• Emby同步删除插件支持GET模式，配置更简单，支持消息推送。
• 恢复了实验室-》WEB增强识别功能，在个别资源匹配上有效果。
• 新增两个认证合作站点。
• 增加多个环境的可执行文件打包。

注意：
1、升级前已启用的插件需要重新安装一下，需要豆瓣同步功能也需要重新安装一下豆瓣同步插件，已有配置不会丢失。 2、目前已支持以下认证站点（按接入时间先后）：SharkPT、HHClub、Audiences、HDDolby、Piggo、ZmPT、FreeFarm、HDFans，另外支持IYUU（需要先在IYUU中完成站点认证）。