### PR TITLE
:sparkles: refresh media library plugin adds delay refresh capability (#2910)

### DIFF
--- a/app/plugins/modules/libraryrefresh.py
+++ b/app/plugins/modules/libraryrefresh.py
@@ -2,13 +2,16 @@ from app.mediaserver import MediaServer
 from app.plugins import EventHandler
 from app.plugins.modules._base import _IPluginModule
 from app.utils.types import EventType
+from datetime import datetime, timedelta
+from app.utils import ExceptionUtils
+from apscheduler.schedulers.background import BackgroundScheduler
 
 
 class LibraryRefresh(_IPluginModule):
     # 插件名称
-    module_name = "实时刷新媒体库"
+    module_name = "刷新媒体库"
     # 插件描述
-    module_desc = "入库完成后实时刷新媒体库服务器海报墙。"
+    module_desc = "入库完成后刷新媒体库服务器海报墙。"
     # 插件图标
     module_icon = "refresh.png"
     # 主题色
@@ -28,6 +31,8 @@ class LibraryRefresh(_IPluginModule):
 
     # 私有属性
     _enable = False
+    _scheduler = None
+    _refresh_delay = 0
 
     mediaserver = None
 
@@ -35,6 +40,26 @@ class LibraryRefresh(_IPluginModule):
         self.mediaserver = MediaServer()
         if config:
             self._enable = config.get("enable")
+            try:
+                # 延迟时间
+                delay = int(float(config.get("delay") or 0))
+                if delay < 0:
+                    delay = 0
+                self._refresh_delay = delay
+            except Exception as e:
+                ExceptionUtils.exception_traceback(e)
+                self._refresh_delay = 0
+
+        self.stop_service()
+
+        if not self._enable :
+            return
+
+        if self._refresh_delay > 0:
+            self.info(f"媒体库延迟刷新服务启动，延迟 {self._refresh_delay} 秒刷新媒体库")
+            self._scheduler = BackgroundScheduler()
+        else:
+            self.info("媒体库实时刷新服务启动")
 
     def get_state(self):
         return self._enable
@@ -49,31 +74,45 @@ class LibraryRefresh(_IPluginModule):
                     # 同一行
                     [
                         {
-                            'title': '开启媒体库实时刷新',
+                            'title': '开启媒体库刷新',
                             'required': "",
                             'tooltip': 'Emby已有电视剧新增剧集时只会刷新对应电视剧，其它场景下如开启了二级分类则只刷新二级分类对应媒体库，否则刷新整库；Jellyfin/Plex只支持刷新整库',
                             'type': 'switch',
                             'id': 'enable',
                         }
                     ],
+                    [
+                        {
+                            'title': '延迟刷新时间',
+                            'required': "",
+                            'tooltip': '延迟刷新时间，单位秒，0或留空则不延迟',
+                            'type': 'text',
+                            'content': [
+                                {
+                                    'id': 'delay',
+                                    'placeholder': '0',
+                                }
+                            ]
+                        }
+                    ]
                 ]
             }
         ]
 
     def stop_service(self):
-        pass
+        """
+        退出插件
+        """
+        try:
+            if self._scheduler:
+                self._scheduler.remove_all_jobs()
+                if self._scheduler.running:
+                    self._scheduler.shutdown()
+                self._scheduler = None
+        except Exception as e:
+            print(str(e))
 
-    @EventHandler.register([
-        EventType.TransferFinished,
-        EventType.RefreshMediaServer
-    ])
-    def refresh(self, event):
-        """
-        监听入库完成事件
-        """
-        if not self._enable:
-            return
-        event_data = event.event_data
+    def __refresh_library(self, event_data):
         mediaserver_type = self.mediaserver.get_type().value
         media_info = event_data.get("media_info")
         if media_info:
@@ -91,3 +130,30 @@ class LibraryRefresh(_IPluginModule):
         else:
             self.info(f"媒体服务器 {mediaserver_type} 刷新整库 ...")
             self.mediaserver.refresh_root_library()
+
+    @EventHandler.register([
+        EventType.TransferFinished,
+        EventType.RefreshMediaServer
+    ])
+    def refresh(self, event):
+        """
+        监听入库完成事件
+        """
+        if not self._enable:
+            return
+
+        if self._refresh_delay > 0:
+            # 计算延迟时间
+            run_date = datetime.now() + timedelta(seconds=self._refresh_delay)
+
+            # 使用 date 触发器添加任务到调度器
+            formatted_run_date = run_date.strftime("%Y-%m-%d %H:%M:%S")
+            self.info(f"新增延迟刷新任务，将在 {formatted_run_date} 刷新媒体库")
+            self._scheduler.add_job(func=self.__refresh_library, args=[event.event_data], trigger='date', run_date=run_date)
+
+            # 启动调度器（懒启动）
+            if not self._scheduler.running:
+              self._scheduler.start()
+        else:
+            # 不延迟刷新
+            self.__refresh_library(event.event_data)


### PR DESCRIPTION
#### 🎯 PR 目的
为“实时刷新媒体库”插件增加通过配置开启延迟刷新的能力。

#### 🪶 修改描述
- 插件名称修改：由于可以延迟刷新，所以将插件名称改为“刷新媒体库”
- 新增配置项：新增延迟刷新时间配置项

#### 👌 关联 Issue #2910