### PR TITLE
fix: 朱雀辅种

### DIFF
--- a/app/plugins/modules/iyuuautoseed.py
+++ b/app/plugins/modules/iyuuautoseed.py
@@ -586,11 +586,14 @@ class IYUUAutoSeed(_IPluginModule):
                 ).replace(
                     "/{}",
                     "/{id}"
+                ).replace(
+                    "/{torrent_key}",
+                    ""
                 ).format(
                     **{
                         "id": seed.get("torrent_id"),
                         "passkey": site.get("passkey") or '',
-                        "uid": site.get("uid") or ''
+                        "uid": site.get("uid") or '',
                     }
                 )
                 if download_url.count("{"):


### PR DESCRIPTION
朱雀下载种子如果没有Cookie的情况需要加torrent_key 才可下载
因为管理了cookie所以修改了一下 