### PR TITLE
fix 更新QB种子自动管理模式逻辑/#4381

### DIFF
--- a/app/brushtask.py
+++ b/app/brushtask.py
@@ -602,8 +602,7 @@ class BrushTask(object):
             download_dir=download_dir,
             download_setting="-2",
             download_limit=download_limit,
-            upload_limit=upload_limit,
-            is_auto=False if download_dir else None
+            upload_limit=upload_limit
         )
         if not download_id:
             # 下载失败

--- a/app/conf/moduleconf.py
+++ b/app/conf/moduleconf.py
@@ -574,9 +574,11 @@ class ModuleConf(object):
                     "id": "qbittorrent_torrent_management",
                     "required": False,
                     "title": "种子管理模式",
-                    "tooltip": """默认：Torrent管理模式应用Qbittorrent下载器-选项-下载-保存管理中设置；
+                    "tooltip": """默认：Torrent管理模式应用Qbittorrent下载器-选项-下载-保存管理中的设置；
                                 手动：Torrent管理模式为手动，下载目录由NAStool传递的下载目录决定；
-                                自动：Torrent管理模式为自动，下载目录由NAStool传递的分类及下载器中分类保存路径决定，需要在NAStool下载目录设置中配置分类标签""",
+                                自动：Torrent管理模式为自动，下载目录由NAStool传递的分类决定；
+                                自动管理模式下，NAStool将在启动时根据下载目录设置为下载器创建相应分类。
+                                如添加种子时，下载器中无相应分类则NAStool将自动创建分类。""",
                     "type": "select",
                     "options": {
                         "default": "默认",

--- a/app/downloader/client/qbittorrent.py
+++ b/app/downloader/client/qbittorrent.py
@@ -87,13 +87,13 @@ class Qbittorrent(_IDownloadClient):
         try:
             if is_edit:
                 self.qbc.torrent_categories.edit_category(name=name, save_path=save_path)
-                log.info(f"【{self.name}】更新分类：{name}，路径：{save_path}")
+                log.info(f"【{self.client_name}】{self.name} 更新分类：{name}，路径：{save_path}")
             else:
                 self.qbc.torrent_categories.create_category(name=name, save_path=save_path)
-                log.info(f"【{self.name}】创建分类：{name}，路径：{save_path}")
+                log.info(f"【{self.client_name}】{self.name} 创建分类：{name}，路径：{save_path}")
         except Exception as err:
             ExceptionUtils.exception_traceback(err)
-            log.error(f"【{self.name}】创建分类：{name}，路径：{save_path} 错误：{str(err)}")
+            log.error(f"【{self.client_name}】{self.name} 创建分类：{name}，路径：{save_path} 错误：{str(err)}")
 
     def check_category(self, category="", save_path=""):
         """
@@ -164,7 +164,7 @@ class Qbittorrent(_IDownloadClient):
             return qbt
         except Exception as err:
             ExceptionUtils.exception_traceback(err)
-            log.error(f"【{self.name}】qBittorrent连接出错：{str(err)}")
+            log.error(f"【{self.client_name}】{self.name} 连接出错：{str(err)}")
             return None
 
     def get_status(self):
@@ -273,17 +273,17 @@ class Qbittorrent(_IDownloadClient):
                 continue
             # 开启标签隔离，未包含指定标签的不处理
             if tag and tag not in torrent_tags:
-                log.debug(f"【{self.name}】开启标签隔离，但 {torrent.get('name')} 未包含指定标签：{tag}")
+                log.debug(f"【{self.client_name}】{self.name} 开启标签隔离， {torrent.get('name')} 未包含指定标签：{tag}")
                 continue
             path = torrent.get("save_path")
             # 无法获取下载路径的不处理
             if not path:
-                log.debug(f"【{self.name}】{torrent.get('name')} 未获取到下载保存路径")
+                log.debug(f"【{self.client_name}】{self.name} 未获取到 {torrent.get('name')} 下载保存路径")
                 continue
             true_path, replace_flag = self.get_replace_path(path, self.download_dir)
             # 开启目录隔离，未进行目录替换的不处理
             if match_path and not replace_flag:
-                log.debug(f"【{self.name}】开启目录隔离，但 {torrent.get('name')} 未匹配下载目录范围")
+                log.debug(f"【{self.client_name}】{self.name} 开启目录隔离， {torrent.get('name')} 未匹配下载目录范围")
                 continue
             content_path = torrent.get("content_path")
             if content_path:

--- a/app/downloader/client/qbittorrent.py
+++ b/app/downloader/client/qbittorrent.py
@@ -29,11 +29,16 @@ class Qbittorrent(_IDownloadClient):
     username = None
     password = None
     download_dir = []
+    name = "测试"
 
     def __init__(self, config):
         self._client_config = config
         self.init_config()
         self.connect()
+        # 种子自动管理模式，根据下载路径设置为下载器设置分类
+        self.init_torrent_management()
+        # 设置未完成种子添加!qb后缀
+        self.qbc.app_set_preferences({"incomplete_files_ext": True})
 
     def init_config(self):
         if self._client_config:
@@ -42,16 +47,90 @@ class Qbittorrent(_IDownloadClient):
             self.username = self._client_config.get('username')
             self.password = self._client_config.get('password')
             self.download_dir = self._client_config.get('download_dir')
+            self.name = self._client_config.get('name') or ""
             # 种子管理模式
-            match self._client_config.get('torrent_management'):
-                case "default":
-                    self._torrent_management = None
-                case "manual":
-                    self._torrent_management = False
-                case "auto":
-                    self._torrent_management = True
-                case _:
-                    self._torrent_management = False
+            self._torrent_management = self._client_config.get('torrent_management')
+            if self._torrent_management not in ["default", "manual", "auto"]:
+                self._torrent_management = "default"
+
+    def init_torrent_management(self):
+        # 手动
+        if self._torrent_management == "manual":
+            return
+        # 默认则查询当前下载器管理模式
+        if self._torrent_management == "default":
+            if not self.qbc.app_preferences().get("auto_tmm_enabled"):
+                return
+        # 获取下载器目前的分类信息
+        categories = self.qbc.torrent_categories.categories
+        # 更新下载器中分类设置
+        for dir_item in self.download_dir:
+            dtype = dir_item.get("type")
+            category = dir_item.get("category")
+            label = dir_item.get("label")
+            save_path = dir_item.get("save_path")
+            # 分类名中不能行 \\ 和 / ，替换为 >
+            category_name = (label or category or dtype or save_path).replace("\\", ">").replace("/", ">")
+            category_item = categories.get(category_name)
+            if not category_item:
+                # 分类不存在，则创建
+                self.update_category(name=category_name, save_path=save_path)
+            else:
+                # 如果分类存在，但是路径不一致，则更新
+                if os.path.normpath(category_item.get("savePath")) != os.path.normpath(save_path):
+                    self.update_category(name=category_name, save_path=save_path, is_edit=True)
+
+    def update_category(self, name, save_path, is_edit=False):
+        """
+        更新分类
+        """
+        try:
+            if is_edit:
+                self.qbc.torrent_categories.edit_category(name=name, save_path=save_path)
+                log.info(f"【{self.name}】更新分类：{name}，路径：{save_path}")
+            else:
+                self.qbc.torrent_categories.create_category(name=name, save_path=save_path)
+                log.info(f"【{self.name}】创建分类：{name}，路径：{save_path}")
+        except Exception as err:
+            ExceptionUtils.exception_traceback(err)
+            log.error(f"【{self.name}】创建分类：{name}，路径：{save_path} 错误：{str(err)}")
+
+    def check_category(self, category="", save_path=""):
+        """
+        检查分类
+        """
+        category_name = "默认下载路径"
+        # 获取下载器中的分类信息
+        categories = self.qbc.torrent_categories.categories
+        # 有分类时：
+        if category:
+            # 分类名中不能行 \\ 和 / ，替换为 >
+            category_name = category.replace("\\", ">").replace("/", ">")
+            category_item = categories.get(category_name)
+            # 查找分类是否存在
+            if category_item:
+                # 分类存在
+                if save_path and os.path.normpath(category_item.get("savePath")) != os.path.normpath(save_path):
+                    # 如果存在，但是路径不一致，则创建新分类
+                    extra = save_path.replace('\\', '/').replace("/", ">")
+                    category_name = f"{category_name}>{extra}"
+                    self.update_category(name=category_name, save_path=save_path)
+                return category_name
+            else:
+                # 不存在则创建分类
+                self.update_category(name=category_name, save_path=save_path)
+                return category_name
+        # 无分类，有路径时
+        if save_path:
+            # 以保存路径为分类名
+            category_name = save_path.replace("\\", ">").replace("/", ">")
+            # 查找分类是否存在
+            if categories.get(category_name):
+                return category_name
+            # 不存在时，创建分类
+            self.update_category(name=category_name, save_path=save_path)
+            return category_name
+        return category_name
 
     @classmethod
     def match(cls, ctype):
@@ -85,7 +164,7 @@ class Qbittorrent(_IDownloadClient):
             return qbt
         except Exception as err:
             ExceptionUtils.exception_traceback(err)
-            log.error(f"【{self.client_name}】qBittorrent连接出错：{str(err)}")
+            log.error(f"【{self.name}】qBittorrent连接出错：{str(err)}")
             return None
 
     def get_status(self):
@@ -194,17 +273,17 @@ class Qbittorrent(_IDownloadClient):
                 continue
             # 开启标签隔离，未包含指定标签的不处理
             if tag and tag not in torrent_tags:
-                log.debug(f"【{self.client_name}】开启标签隔离，但 {torrent.get('name')} 未包含指定标签：{tag}")
+                log.debug(f"【{self.name}】开启标签隔离，但 {torrent.get('name')} 未包含指定标签：{tag}")
                 continue
             path = torrent.get("save_path")
             # 无法获取下载路径的不处理
             if not path:
-                log.debug(f"【{self.client_name}】{torrent.get('name')} 未获取到下载保存路径")
+                log.debug(f"【{self.name}】{torrent.get('name')} 未获取到下载保存路径")
                 continue
             true_path, replace_flag = self.get_replace_path(path, self.download_dir)
             # 开启目录隔离，未进行目录替换的不处理
             if match_path and not replace_flag:
-                log.debug(f"【{self.client_name}】开启目录隔离，但 {torrent.get('name')} 未匹配下载目录范围")
+                log.debug(f"【{self.name}】开启目录隔离，但 {torrent.get('name')} 未匹配下载目录范围")
                 continue
             content_path = torrent.get("content_path")
             if content_path:
@@ -323,7 +402,6 @@ class Qbittorrent(_IDownloadClient):
     def add_torrent(self,
                     content,
                     is_paused=False,
-                    is_auto=None,
                     download_dir=None,
                     tag=None,
                     category=None,
@@ -338,7 +416,6 @@ class Qbittorrent(_IDownloadClient):
         添加种子
         :param content: 种子urls或文件
         :param is_paused: 添加后暂停
-        :param is_auto: 自动管理
         :param tag: 标签
         :param download_dir: 下载路径
         :param category: 分类
@@ -387,9 +464,20 @@ class Qbittorrent(_IDownloadClient):
         else:
             seeding_time_limit = None
         try:
-            if is_auto is None:
-                is_auto = self._torrent_management
+            is_auto = False
+            match self._torrent_management:
+                case "default":
+                    if self.qbc.app_preferences().get("auto_tmm_enabled"):
+                        is_auto = True
+                case "auto":
+                    is_auto = True
+                case "manual":
+                    is_auto = False
+                case _:
+                    is_auto = False
+            # 自动管理模式
             if is_auto:
+                category = self.check_category(category, save_path)
                 save_path = None
             qbc_ret = self.qbc.torrents_add(urls=urls,
                                             torrent_files=torrent_files,

--- a/app/downloader/client/transmission.py
+++ b/app/downloader/client/transmission.py
@@ -34,6 +34,7 @@ class Transmission(_IDownloadClient):
     username = None
     password = None
     download_dir = []
+    name = "测试"
 
     def __init__(self, config):
         self._client_config = config
@@ -47,6 +48,7 @@ class Transmission(_IDownloadClient):
             self.username = self._client_config.get('username')
             self.password = self._client_config.get('password')
             self.download_dir = self._client_config.get('download_dir')
+            self.name = self._client_config.get('name') or ""
 
     @classmethod
     def match(cls, ctype):
@@ -74,7 +76,7 @@ class Transmission(_IDownloadClient):
             return trt
         except Exception as err:
             ExceptionUtils.exception_traceback(err)
-            log.error(f"【{self.client_name}】transmission连接出错：{str(err)}")
+            log.error(f"【{self.name}】transmission连接出错：{str(err)}")
             return None
 
     def get_status(self):
@@ -171,7 +173,7 @@ class Transmission(_IDownloadClient):
         # 打标签
         try:
             self.trc.change_torrent(labels=tags, ids=ids)
-            log.info(f"【{self.client_name}】设置transmission种子标签成功")
+            log.info(f"【{self.name}】设置transmission种子标签成功")
         except Exception as err:
             ExceptionUtils.exception_traceback(err)
 
@@ -263,7 +265,7 @@ class Transmission(_IDownloadClient):
         for torrent in torrents:
             # 3.0版本以下的Transmission没有labels
             if not hasattr(torrent, "labels"):
-                log.error(f"【{self.client_name}】当前transmission版本可能过低，无labels属性，请安装3.0以上版本！")
+                log.error(f"【{self.name}】当前transmission版本可能过低，无labels属性，请安装3.0以上版本！")
                 break
             torrent_tags = torrent.labels or ""
             # 含"已整理"tag的不处理
@@ -271,17 +273,17 @@ class Transmission(_IDownloadClient):
                 continue
             # 开启标签隔离，未包含指定标签的不处理
             if tag and tag not in torrent_tags:
-                log.debug(f"【{self.client_name}】开启标签隔离，但 {torrent.name} 未包含指定标签：{tag}")
+                log.debug(f"【{self.name}】开启标签隔离，但 {torrent.name} 未包含指定标签：{tag}")
                 continue
             path = torrent.download_dir
             # 无法获取下载路径的不处理
             if not path:
-                log.debug(f"【{self.client_name}】{torrent.name} 未获取到下载保存路径")
+                log.debug(f"【{self.name}】{torrent.name} 未获取到下载保存路径")
                 continue
             true_path, replace_flag = self.get_replace_path(path, self.download_dir)
             # 开启目录隔离，未进行目录替换的不处理
             if match_path and not replace_flag:
-                log.debug(f"【{self.client_name}】开启目录隔离，但 {torrent.name} 未匹配下载目录范围")
+                log.debug(f"【{self.name}】开启目录隔离，但 {torrent.name} 未匹配下载目录范围")
                 continue
             trans_tasks.append({
                 'path': os.path.join(true_path, torrent.name).replace("\\", "/"),

--- a/app/downloader/client/transmission.py
+++ b/app/downloader/client/transmission.py
@@ -40,6 +40,8 @@ class Transmission(_IDownloadClient):
         self._client_config = config
         self.init_config()
         self.connect()
+        # 设置未完成种子添加!part后缀
+        self.trc.set_session(rename_partial_files=True)
 
     def init_config(self):
         if self._client_config:
@@ -76,7 +78,7 @@ class Transmission(_IDownloadClient):
             return trt
         except Exception as err:
             ExceptionUtils.exception_traceback(err)
-            log.error(f"【{self.name}】transmission连接出错：{str(err)}")
+            log.error(f"【{self.client_name}】{self.name} 连接出错：{str(err)}")
             return None
 
     def get_status(self):
@@ -173,7 +175,7 @@ class Transmission(_IDownloadClient):
         # 打标签
         try:
             self.trc.change_torrent(labels=tags, ids=ids)
-            log.info(f"【{self.name}】设置transmission种子标签成功")
+            log.info(f"【{self.client_name}】{self.name} 设置种子标签成功")
         except Exception as err:
             ExceptionUtils.exception_traceback(err)
 
@@ -265,7 +267,7 @@ class Transmission(_IDownloadClient):
         for torrent in torrents:
             # 3.0版本以下的Transmission没有labels
             if not hasattr(torrent, "labels"):
-                log.error(f"【{self.name}】当前transmission版本可能过低，无labels属性，请安装3.0以上版本！")
+                log.error(f"【{self.client_name}】{self.name} 版本可能过低，无labels属性，请安装3.0以上版本！")
                 break
             torrent_tags = torrent.labels or ""
             # 含"已整理"tag的不处理
@@ -273,17 +275,17 @@ class Transmission(_IDownloadClient):
                 continue
             # 开启标签隔离，未包含指定标签的不处理
             if tag and tag not in torrent_tags:
-                log.debug(f"【{self.name}】开启标签隔离，但 {torrent.name} 未包含指定标签：{tag}")
+                log.debug(f"【{self.client_name}】{self.name} 开启标签隔离， {torrent.name} 未包含指定标签：{tag}")
                 continue
             path = torrent.download_dir
             # 无法获取下载路径的不处理
             if not path:
-                log.debug(f"【{self.name}】{torrent.name} 未获取到下载保存路径")
+                log.debug(f"【{self.client_name}】{self.name} 未获取到 {torrent.name} 下载保存路径")
                 continue
             true_path, replace_flag = self.get_replace_path(path, self.download_dir)
             # 开启目录隔离，未进行目录替换的不处理
             if match_path and not replace_flag:
-                log.debug(f"【{self.name}】开启目录隔离，但 {torrent.name} 未匹配下载目录范围")
+                log.debug(f"【{self.client_name}】{self.name} 开启目录隔离，但 {torrent.name} 未匹配下载目录范围")
                 continue
             trans_tasks.append({
                 'path': os.path.join(true_path, torrent.name).replace("\\", "/"),

--- a/app/downloader/downloader.py
+++ b/app/downloader/downloader.py
@@ -247,6 +247,7 @@ class Downloader:
         ctype = downloader_conf.get("type")
         config = downloader_conf.get("config")
         config["download_dir"] = downloader_conf.get("download_dir")
+        config["name"] = downloader_conf.get("name")
         with client_lock:
             if not self.clients.get(str(did)):
                 self.clients[str(did)] = self.__build_class(ctype, config)
@@ -263,8 +264,7 @@ class Downloader:
                  download_limit=None,
                  torrent_file=None,
                  in_from=None,
-                 user_name=None,
-                 is_auto=None):
+                 user_name=None):
         """
         添加下载任务，根据当前使用的下载器分别调用不同的客户端处理
         :param media_info: 需下载的媒体信息，含URL地址
@@ -278,7 +278,6 @@ class Downloader:
         :param torrent_file: 种子文件路径
         :param in_from: 来源
         :param user_name: 用户名
-        :param is_auto: 是否开始自动管理模式
         :return: 下载器类型, 种子ID，错误信息
         """
 
@@ -449,7 +448,6 @@ class Downloader:
                 # 布局默认原始
                 ret = downloader.add_torrent(content,
                                              is_paused=is_paused,
-                                             is_auto=is_auto,
                                              download_dir=download_dir,
                                              tag=tags,
                                              category=category,

--- a/app/filter.py
+++ b/app/filter.py
@@ -107,8 +107,6 @@ class Filter:
             return True, 0, "不过滤"
         # 过滤使用的文本
         title = meta_info.org_string
-        if meta_info.labels:
-            title = f"{title} {meta_info.labels}"
         if meta_info.subtitle:
             title = f"{title} {meta_info.subtitle}"
         # 过滤规则组
@@ -259,8 +257,6 @@ class Filter:
         """
         # 过滤包含，排除，关键字使用的文本
         text = meta_info.org_string
-        if meta_info.labels:
-            text = f"{text} {meta_info.labels}"
         if meta_info.subtitle:
             text = f"{text} {meta_info.subtitle}"
         # 过滤质量

--- a/app/filter.py
+++ b/app/filter.py
@@ -257,70 +257,67 @@ class Filter:
         :param downloadvolumefactor: 种子的下载因子 传空不过滤
         :return: 是否匹配，匹配的优先值，匹配信息，值越大越优先
         """
-        # 过滤制作组/字幕组使用的文本
-        title = text = meta_info.org_string
         # 过滤包含，排除，关键字使用的文本
+        text = meta_info.org_string
         if meta_info.labels:
             text = f"{text} {meta_info.labels}"
         if meta_info.subtitle:
             text = f"{text} {meta_info.subtitle}"
         # 过滤质量
-        restype = filter_args.get("restype")
-        if restype:
-            restype_re = ModuleConf.TORRENT_SEARCH_PARAMS["restype"].get(restype)
+        if filter_args.get("restype"):
+            restype_re = ModuleConf.TORRENT_SEARCH_PARAMS["restype"].get(filter_args.get("restype"))
             if not meta_info.get_edtion_string():
-                return False, 0, f"{title} 不符合质量 {restype} 要求"
+                return False, 0, f"{meta_info.org_string} 不符合质量 {filter_args.get('restype')} 要求"
             if restype_re and not re.search(r"%s" % restype_re, meta_info.get_edtion_string(), re.I):
-                return False, 0, f"{title} 不符合质量 {restype} 要求"
+                return False, 0, f"{meta_info.org_string} 不符合质量 {filter_args.get('restype')} 要求"
         # 过滤分辨率
-        pix = filter_args.get("pix")
-        if pix:
-            pix_re = ModuleConf.TORRENT_SEARCH_PARAMS["pix"].get(pix)
+        if filter_args.get("pix"):
+            pix_re = ModuleConf.TORRENT_SEARCH_PARAMS["pix"].get(filter_args.get("pix"))
             if not meta_info.resource_pix:
-                return False, 0, f"{title} 不符合分辨率 {pix} 要求"
+                return False, 0, f"{meta_info.org_string} 不符合分辨率 {filter_args.get('pix')} 要求"
             if pix_re and not re.search(r"%s" % pix_re, meta_info.resource_pix, re.I):
-                return False, 0, f"{title} 不符合分辨率 {pix} 要求"
+                return False, 0, f"{meta_info.org_string} 不符合分辨率 {filter_args.get('pix')} 要求"
         # 过滤制作组/字幕组
-        team = filter_args.get("team")
-        if team:
+        if filter_args.get("team"):
+            team = filter_args.get("team")
             if not meta_info.resource_team:
-                resource_team = self.rg_matcher.match(title=title, groups=team)
+                resource_team = self.rg_matcher.match(
+                    title=meta_info.org_string,
+                    groups=team)
                 if not resource_team:
-                    return False, 0, f"{title} 不符合制作组/字幕组 {team} 要求"
+                    return False, 0, f"{meta_info.org_string} 不符合制作组/字幕组 {team} 要求"
                 else:
                     meta_info.resource_team = resource_team
             elif not re.search(r"%s" % team, meta_info.resource_team, re.I):
-                return False, 0, f"{title} 不符合制作组/字幕组 {team} 要求"
+                return False, 0, f"{meta_info.org_string} 不符合制作组/字幕组 {team} 要求"
         # 过滤促销
-        sp_state = filter_args.get("sp_state")
-        if sp_state:
-            ul_factor, dl_factor = sp_state.split()
+        if filter_args.get("sp_state"):
+            ul_factor, dl_factor = filter_args.get("sp_state").split()
             if uploadvolumefactor and ul_factor not in ("*", str(uploadvolumefactor)):
-                return False, 0, f"{title} 不符合促销要求"
+                return False, 0, f"{meta_info.org_string} 不符合促销要求"
             if downloadvolumefactor and dl_factor not in ("*", str(downloadvolumefactor)):
-                return False, 0, f"{title} 不符合促销要求"
+                return False, 0, f"{meta_info.org_string} 不符合促销要求"
         # 过滤包含
-        include = filter_args.get("include")
-        if include:
+        if filter_args.get("include"):
+            include = filter_args.get("include")
             if not re.search(r"%s" % include, text, re.I):
-                return False, 0, f"{title} 不符合包含 {include} 要求"
+                return False, 0, f"{meta_info.org_string} 不符合包含 {include} 要求"
         # 过滤排除
-        exclude = filter_args.get("exclude")
-        if exclude:
+        if filter_args.get("exclude"):
+            exclude = filter_args.get("exclude")
             if re.search(r"%s" % exclude, text, re.I):
-                return False, 0, f"{title} 不符合排除 {exclude} 要求"
+                return False, 0, f"{meta_info.org_string} 不符合排除 {exclude} 要求"
         # 过滤关键字
-        key = filter_args.get("key")
-        if key:
+        if filter_args.get("key"):
+            key = filter_args.get("key")
             if not re.search(r"%s" % key, text, re.I):
-                return False, 0, f"{title} 不符合 {key} 要求"
+                return False, 0, f"{meta_info.org_string} 不符合 {key} 要求"
         # 过滤过滤规则，-1表示不使用过滤规则，空则使用默认过滤规则
-        rule = filter_args.get("rule")
-        if rule:
+        if filter_args.get("rule"):
             # 已设置默认规则
-            match_flag, order_seq, rule_name = self.check_rules(meta_info, rule)
+            match_flag, order_seq, rule_name = self.check_rules(meta_info, filter_args.get("rule"))
             match_msg = "%s 大小：%s 促销：%s 不符合订阅/站点过滤规则 %s 要求" % (
-                title,
+                meta_info.org_string,
                 StringUtils.str_filesize(meta_info.size),
                 meta_info.get_volume_factor_string(),
                 rule_name
@@ -330,7 +327,7 @@ class Filter:
             # 默认过滤规则
             match_flag, order_seq, rule_name = self.check_rules(meta_info)
             match_msg = "%s 大小：%s 促销：%s 不符合默认过滤规则 %s 要求" % (
-                title,
+                meta_info.org_string,
                 StringUtils.str_filesize(meta_info.size),
                 meta_info.get_volume_factor_string(),
                 rule_name

--- a/app/plugins/modules/iyuuautoseed.py
+++ b/app/plugins/modules/iyuuautoseed.py
@@ -647,7 +647,7 @@ class IYUUAutoSeed(_IPluginModule):
         meta_info = MetaInfo(title="IYUU自动辅种")
         meta_info.set_torrent_info(site=site_info.get("name"),
                                    enclosure=torrent_url)
-        # 辅种任务默认暂停，关闭自动管理模式
+        # 辅种任务默认暂停
         _, download_id, retmsg = self.downloader.download(
             media_info=meta_info,
             is_paused=True,
@@ -655,7 +655,6 @@ class IYUUAutoSeed(_IPluginModule):
             downloader_id=downloader,
             download_dir=save_path,
             download_setting="-2",
-            is_auto=False
         )
         if not download_id:
             # 下载失败

--- a/app/plugins/modules/torrenttransfer.py
+++ b/app/plugins/modules/torrenttransfer.py
@@ -467,7 +467,6 @@ class TorrentTransfer(_IPluginModule):
                     downloader_id=todownloader,
                     download_dir=download_dir,
                     download_setting="-2",
-                    is_auto=False
                 )
                 if not download_id:
                     # 下载失败

--- a/app/rsschecker.py
+++ b/app/rsschecker.py
@@ -356,7 +356,6 @@ class RssChecker(object):
                 downloader_id, ret, ret_msg = self.downloader.download(
                     media_info=media,
                     download_dir=taskinfo.get("save_path"),
-                    is_auto=False if taskinfo.get("save_path") else None,
                     download_setting=taskinfo.get("download_setting"),
                     in_from=SearchType.USERRSS)
                 if ret:
@@ -689,7 +688,6 @@ class RssChecker(object):
             downloader_id, ret, ret_msg = self.downloader.download(
                 media_info=media,
                 download_dir=taskinfo.get("save_path"),
-                is_auto=False if taskinfo.get("save_path") else None,
                 download_setting=taskinfo.get("download_setting"),
                 in_from=SearchType.USERRSS)
             downloader_name = self.downloader.get_downloader_conf(downloader_id).get("name")

--- a/web/templates/rss/user_rss.html
+++ b/web/templates/rss/user_rss.html
@@ -420,7 +420,7 @@
               </div>
               <div class="col-lg-6">
                 <div class="mb-3">
-                  <label class="form-label">保存路径 <span class="form-help" title="设置后，如下载器为Qbittorrent则该任务下载种子不启用自动管理模式" data-bs-toggle="tooltip">?</span></label>
+                  <label class="form-label">保存路径 <span class="form-help" data-bs-toggle="tooltip">?</span></label>
                   <select class="form-select" id="userrss_rss_save_path" aria-label="保存目录"  onchange="check_manual_input_path('userrss_rss_save_path','userrss_rss_save_path_manual')">
                   <input type="text" value="" id="userrss_rss_save_path_manual" class="form-control" style="display: none" placeholder="留空自动选择保存路径">
                   </select>


### PR DESCRIPTION
更新了下QB种子自动管理模式逻辑，开启自动后：
1、添加种子时只传分类，不传保存路径
2、qb实例化时，根据下载目录设置，为下载器更新或添加分类
3、下载种子时：
 有分类，有下载路径：查询分类在下载器中若不存在，则创建；若存在且路径不相同，创建新分类

有分类，无下载路径：查询分类在下载器中若不存在，则创建；会下到默认目录

无分类，有下载路径：查询下载路径合成的分类在下载器中若不存在，则创建

无分类，无下载路径：使用分类 默认下载路径，会下到默认目录