### PR TITLE
fix win docker无法下载转移文件

### DIFF
--- a/app/utils/path_utils.py
+++ b/app/utils/path_utils.py
@@ -102,8 +102,8 @@ class PathUtils:
         """
         if not path1 or not path2:
             return False
-        path1 = os.path.normpath(path1)
-        path2 = os.path.normpath(path2)
+        path1 = os.path.normpath(path1).replace("\\", "/")
+        path2 = os.path.normpath(path2).replace("\\", "/")
         if path1 == path2:
             return True
         path = os.path.dirname(path2)


### PR DESCRIPTION
win地址在linux环境用os.path.dirname会变空字符串，但反过来linux地址在win环境用os.path.dirname能正常取上级目录

替换路径时，用了这个函数来判断种子保存路径是否在下载器设置中

![image](https://user-images.githubusercontent.com/16237201/233232173-a0501e03-b36f-40c2-877d-1dfa0eb6d994.png)
