### PR TITLE
fix: 修复自定义订阅代理

### DIFF
--- a/app/downloader/downloader.py
+++ b/app/downloader/downloader.py
@@ -264,7 +264,8 @@ class Downloader:
                  download_limit=None,
                  torrent_file=None,
                  in_from=None,
-                 user_name=None):
+                 user_name=None,
+                 proxy=None):
         """
         添加下载任务，根据当前使用的下载器分别调用不同的客户端处理
         :param media_info: 需下载的媒体信息，含URL地址
@@ -278,6 +279,7 @@ class Downloader:
         :param torrent_file: 种子文件路径
         :param in_from: 来源
         :param user_name: 用户名
+        :param proxy: 是否使用代理，指定该选项为 True/False 会覆盖 site_info 的设置
         :return: 下载器类型, 种子ID，错误信息
         """
 
@@ -332,7 +334,7 @@ class Downloader:
                     cookie=site_info.get("cookie"),
                     ua=site_info.get("ua"),
                     referer=page_url if site_info.get("referer") else None,
-                    proxy=site_info.get("proxy")
+                    proxy=proxy if proxy is not None else site_info.get("proxy")
                 )
 
         # 解析完成

--- a/app/rsschecker.py
+++ b/app/rsschecker.py
@@ -689,7 +689,8 @@ class RssChecker(object):
                 media_info=media,
                 download_dir=taskinfo.get("save_path"),
                 download_setting=taskinfo.get("download_setting"),
-                in_from=SearchType.USERRSS)
+                in_from=SearchType.USERRSS,
+                proxy=taskinfo.get("proxy"))
             downloader_name = self.downloader.get_downloader_conf(downloader_id).get("name")
             if ret:
                 # 插入数据库


### PR DESCRIPTION
最近 mikanani 遭到污染，nastools 自定义订阅即使开启代理下载种子也是失败的。看了下代码，发现目前自定义订阅只在请求 rss 报文时使用了代理，但下载种子时并没有，做了个简单的修复 。