### PR TITLE
fixes #4461：刷流任务未检查发布时间

### DIFF
--- a/app/brushtask.py
+++ b/app/brushtask.py
@@ -766,7 +766,7 @@ class BrushTask(object):
                     max_pubdate = min_max_pubdates[1] if len(min_max_pubdates) > 1 else None
                     localtz = pytz.timezone(Config().get_timezone())
                     localnowtime = datetime.now().astimezone(localtz)
-                    localpubdate = StringUtils.get_time_stamp(pubdate).astimezone(localtz)
+                    localpubdate = pubdate.astimezone(localtz)
                     pudate_hour = int(localnowtime.timestamp() - localpubdate.timestamp()) / 3600
                     log.debug('【Brush】发布时间：%s，当前时间：%s，时间间隔：%f hour' % (
                         localpubdate.isoformat(), localnowtime.isoformat(), pudate_hour))


### PR DESCRIPTION
函数`StringUtils.get_time_stamp(pubdate)`报错阻止继续判断发布时间：'Parser must be a string or character stream, not datetime'。`pubdate` 类型为`datetime`，不需要再次转换类型。