### PR TITLE
fix: 再次修复自定义订阅代理

### DIFF
--- a/app/rsschecker.py
+++ b/app/rsschecker.py
@@ -357,7 +357,8 @@ class RssChecker(object):
                     media_info=media,
                     download_dir=taskinfo.get("save_path"),
                     download_setting=taskinfo.get("download_setting"),
-                    in_from=SearchType.USERRSS)
+                    in_from=SearchType.USERRSS,
+                    proxy=taskinfo.get("proxy"))
                 if ret:
                     # 下载类型的 这里下载成功了 插入数据库
                     self.dbhelper.insert_rss_torrents(media)


### PR DESCRIPTION
发现直接运行自定义订阅任务和预览自定义订阅报文后手动点击下载是不同的入口，之前只改了后面的，把前面的也补上。