### PR TITLE
修正rss两处正则判断 | 媒体元数据识别错误将作品名中的Season去除的bug

### DIFF
--- a/app/rss.py
+++ b/app/rss.py
@@ -471,7 +471,7 @@ class Rss:
                         continue
                     # 匹配关键字或正则表达式
                     search_title = f"{media_info.org_string} {media_info.title} {media_info.year}"
-                    if not re.search(name, search_title, re.I) and name not in search_title:
+                    if not name.lower() in search_title.lower():
                         continue
                 # 媒体匹配成功
                 match_flag = True
@@ -517,7 +517,7 @@ class Rss:
                         continue
                     # 匹配关键字或正则表达式
                     search_title = f"{media_info.org_string} {media_info.title} {media_info.year}"
-                    if not re.search(name, search_title, re.I) and name not in search_title:
+                    if not name.lower() in search_title.lower():
                         continue
                 # 媒体匹配成功
                 match_flag = True


### PR DESCRIPTION
原[if not re.search(name, search_title, re.I) and name not in search_title]判断，若name含有正则匹配特殊字符，会导致匹配错误，改为转小写if in比较

修正媒体元数据识别错误将作品名中的Season去除的bug：如果匹配到季或年份，其前的英文名结尾有Season，说明Season属于标题，不应在后续作为干扰词去除 运行情况：

修正前
The Long Season S01 2023 2160p WEB-DL H265 AAC-HDSWE 和 The Long Season 2023 识别为 The Long (2023) S01

修正后
The Long Season S01 2023 2160p WEB-DL H265 AAC-HDSWE 和 The Long Season 2023 识别为 The Long Season