### PR TITLE
修正当媒体服务器播放地址为本地时，不同场景下主页媒体的链接

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -38,21 +38,28 @@
   </div>
 </div>
 {% if ServerSucess %}
+{% with curdomainleft = request.host.split(':')[0] %}
 <div class="page-body">
   <div class="container-xl">
     <div class="d-grid gap-3 grid-normal-card">
       {% for Library in Librarys %}
         {% if LibrarySyncConf and Library.id|string in LibrarySyncConf %}
-        <a class="card card-link-pop rounded-3 overflow-hidden library-{{ Library.id }}" href="{{ Library.link }}" target="_blank">
-          <custom-img img-class="w-100"
-                      img-src="{{ Library.image }}"
-                      img-ratio="50%"
-                      img-style="object-fit: cover;"
-          ></custom-img>
-          <div class="m-2 text-center">
-            {{ Library.name }}
-          </div>
-        </a>
+        {% set theLibLink = Library.link %}
+          {% if "127.0.0.1" in theLibLink[0:16] %}
+            {% set theLibLink = theLibLink|replace("127.0.0.1",curdomainleft,1) %}
+          {% elif "localhost" in theLibLink[0:16] %}
+            {% set theLibLink = theLibLink|replace("localhost",curdomainleft,1) %}
+          {% endif %}
+          <a class="card card-link-pop rounded-3 overflow-hidden library-{{ Library.id }}" href="{{ theLibLink }}" target="_blank">
+            <custom-img img-class="w-100"
+                        img-src="{{ Library.image }}"
+                        img-ratio="50%"
+                        img-style="object-fit: cover;"
+            ></custom-img>
+            <div class="m-2 text-center">
+              {{ Library.name }}
+            </div>
+          </a>
         {% endif %}
       {% endfor %}
     </div>
@@ -74,7 +81,13 @@
   <div class="container-xl">
     <div class="d-grid gap-3 grid-normal-card align-items-start">
       {% for Resume in Resumes %}
-      <a class="card card-link-pop rounded-3 overflow-hidden resume-{{ Resume.id }}" href="{{ Resume.link }}" target="_blank">
+        {% set theLibLink = Resume.link %}
+        {% if "127.0.0.1" in theLibLink[0:16] %}
+          {% set theLibLink = theLibLink|replace("127.0.0.1",curdomainleft,1) %}
+        {% elif "localhost" in theLibLink[0:16] %}
+          {% set theLibLink = theLibLink|replace("localhost",curdomainleft,1) %}
+        {% endif %}
+      <a class="card card-link-pop rounded-3 overflow-hidden resume-{{ Resume.id }}" href="{{ theLibLink }}" target="_blank">
         <custom-img img-class="w-100"
                     img-src="{{ Resume.image }}"
                     img-ratio="50%"
@@ -114,7 +127,13 @@
   <div class="container-xl">
     <div class="d-grid gap-3 grid-media-card align-items-start">
       {% for Latest in Latests %}
-      <a class="card card-link-pop overflow-hidden rounded-3 latest-{{ Latest.id }}" href="{{ Latest.link }}" target="_blank">
+      {% set theLibLink = Latest.link %}
+        {% if "127.0.0.1" in theLibLink[0:16] %}
+          {% set theLibLink = theLibLink|replace("127.0.0.1",curdomainleft,1) %}
+        {% elif "localhost" in theLibLink[0:16] %}
+          {% set theLibLink = theLibLink|replace("localhost",curdomainleft,1) %}
+        {% endif %}
+      <a class="card card-link-pop overflow-hidden rounded-3 latest-{{ Latest.id }}" href="{{ theLibLink }}" target="_blank">
         <custom-img img-class="w-100"
                     img-src="{{ Latest.image }}"
                     img-ratio="150%"
@@ -130,6 +149,7 @@
   </div>
 </div>
 {% endif %}
+{% endwith %}
 {% else %}
 {{ OOPS.systemerror('媒体服务器连接失败！', '当前无法连接媒体服务器获取数据，请确认Emby/Jellyfin/Plex配置是否正确。') }}
 {% endif %}


### PR DESCRIPTION
当媒体服务器地址为本地时，比如127.0.0.1，则可能存在访问播放地址不唯一的情况
比如在家里播放地址为192.168.1.60，在单位因为设置的IP段不一样，访问播放地址为192.168.2.80 这样即使单独设置播放地址，当媒体播放地址实际为本地127.0.0.1时，在不同场景下，主页媒体链接域名可能与远程IP不一致 导致在主页点击媒体访问到错误网页

修正方法：当媒体服务器播放地址为本地时，加入对nastools当前域名IP判断，替换为当前IP，以适应媒体播放地址实际为本地时，在不同场景IP下的正常访问

修正后运行情况：
当媒体服务器地址位于本地（127.0.0.1、localhost）且播放地址留空，或其播放地址位于本地时，主页“我的媒体库”中展示的媒体链接，由原先的 http://127.0.0.1:xxxx/... 转为http://当前IP:xxxx/...

这样做的意义：
当nas-tools和媒体服务均位于同一nas设备，设置媒体服务器地址为http://127.0.0.1:xxxx，媒体播放地址不固定时（如：家里访问192.168.1.60，单位访问192.168.2.80），nas-tools主页“我的媒体库”中展示的媒体链接自动判断，若为本地地址，即应与当前nas-tools地址IP相同，则用当前IP地址替换127.0.0.1，使媒体链接正常，否则会访问至错误IP