### PR TITLE
fix 登录页背景图依旧无法自动更换问题

### DIFF
--- a/web/backend/wallpaper.py
+++ b/web/backend/wallpaper.py
@@ -7,10 +7,12 @@ from app.utils import RequestUtils, ExceptionUtils
 from config import Config
 
 
-def get_login_wallpaper(time_now=datetime.datetime.now()):
+def get_login_wallpaper(time_now=None):
     """
     获取Base64编码的壁纸图片
     """
+    if not time_now:
+        time_now = datetime.datetime.now()
     wallpaper = Config().get_config('app').get('wallpaper')
     tmdbkey = Config().get_config('app').get('rmt_tmdbkey')
     if (not wallpaper or wallpaper == "themoviedb") and tmdbkey:


### PR DESCRIPTION
默认参数导致 time_now 不会发生变化，参考：https://blog.csdn.net/qq_32799165/article/details/103674892