### PR TITLE
fix 远程转移会在本地创建目录，刮削文件会存在本地而非远程

### DIFF
--- a/app/conf/moduleconf.py
+++ b/app/conf/moduleconf.py
@@ -42,6 +42,9 @@ class ModuleConf(object):
         "move": RmtMode.MOVE
     }
 
+    # 远程转移模式
+    REMOTE_RMT_MODES = [RmtMode.RCLONE, RmtMode.RCLONECOPY, RmtMode.MINIO, RmtMode.MINIOCOPY]
+
     # 消息通知类型
     MESSAGE_CONF = {
         "client": {

--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -393,7 +393,7 @@ class FileTransfer:
                 log.warn("【Rmt】%s 文件已存在" % new_file)
                 continue
             new_dir = os.path.dirname(new_file)
-            if not os.path.exists(new_dir):
+            if not os.path.exists(new_dir) and rmt_mode not in ModuleConf.REMOTE_RMT_MODES:
                 os.makedirs(new_dir)
             retcode = self.__transfer_command(file_item=file,
                                               target_file=new_file,
@@ -419,10 +419,10 @@ class FileTransfer:
         if not os.path.exists(file_item):
             log.warn("【Rmt】%s 不存在" % file_item)
             return -1
-        # 计算目录目录
+        # 计算目的目录
         parent_name = os.path.basename(os.path.dirname(file_item))
         target_dir = os.path.join(target_dir, parent_name)
-        if not os.path.exists(target_dir):
+        if not os.path.exists(target_dir) and rmt_mode not in ModuleConf.REMOTE_RMT_MODES:
             log.debug("【Rmt】正在创建目录：%s" % target_dir)
             os.makedirs(target_dir)
         # 目录
@@ -708,7 +708,7 @@ class FileTransfer:
                     if error_message not in alert_messages:
                         alert_messages.append(error_message)
                     continue
-                if dist_path and not os.path.exists(dist_path):
+                if dist_path and not os.path.exists(dist_path) and rmt_mode not in ModuleConf.REMOTE_RMT_MODES:
                     return __finish_transfer(False, "目录不存在：%s" % dist_path)
 
                 # 判断文件是否已存在，返回：目录存在标志、目录名、文件存在标志、文件名
@@ -785,8 +785,8 @@ class FileTransfer:
                         if error_message not in alert_messages and is_need_insert_unknown:
                             alert_messages.append(error_message)
                         continue
-                    else:
-                        # 创建电录
+                    elif rmt_mode not in ModuleConf.REMOTE_RMT_MODES:
+                        # 创建目录
                         log.debug("【Rmt】正在创建目录：%s" % ret_dir_path)
                         os.makedirs(ret_dir_path)
                 # 转移蓝光原盘
@@ -878,12 +878,14 @@ class FileTransfer:
                     self.scraper.gen_scraper_files(media=media,
                                                    dir_path=ret_dir_path,
                                                    file_name=os.path.basename(ret_dir_path),
-                                                   file_ext=file_ext)
+                                                   file_ext=file_ext,
+                                                   rmt_mode=rmt_mode)
                 else:
                     self.scraper.gen_scraper_files(media=media,
                                                    dir_path=ret_dir_path,
                                                    file_name=os.path.basename(ret_file_path),
-                                                   file_ext=file_ext)
+                                                   file_ext=file_ext,
+                                                   rmt_mode=rmt_mode)
                 # 更新进度
                 self.progress.update(ptype=ProgressKey.FileTransfer,
                                      value=round(total_count / len(Medias) * 100),
@@ -953,7 +955,7 @@ class FileTransfer:
             print("【Rmt】源目录不存在：%s" % s_path)
             return
         if t_path:
-            if not os.path.exists(t_path):
+            if not os.path.exists(t_path) and mode not in ModuleConf.REMOTE_RMT_MODES:
                 print("【Rmt】目的目录不存在：%s" % t_path)
                 return
         rmt_mode = ModuleConf.RMT_MODES.get(mode)
@@ -1205,7 +1207,7 @@ class FileTransfer:
         else:
             new_file = new_file_list[0]
         new_dir = os.path.dirname(new_file)
-        if not os.path.exists(new_dir):
+        if not os.path.exists(new_dir) and sync_transfer_mode not in ModuleConf.REMOTE_RMT_MODES:
             os.makedirs(new_dir)
         return self.__transfer_command(file_item=in_file,
                                        target_file=new_file,

--- a/app/media/scraper.py
+++ b/app/media/scraper.py
@@ -5,14 +5,14 @@ from xml.dom import minidom
 from requests.exceptions import RequestException
 
 import log
-from app.conf import SystemConfig
+from app.conf import SystemConfig, ModuleConf
 from app.helper import FfmpegHelper
 from app.media.douban import DouBan
 from app.media.meta import MetaInfo
 from app.utils.commons import retry
 from config import Config, RMT_MEDIAEXT
-from app.utils import DomUtils, RequestUtils, ExceptionUtils, NfoReader
-from app.utils.types import MediaType, SystemConfigKey
+from app.utils import DomUtils, RequestUtils, ExceptionUtils, NfoReader, SystemUtils
+from app.utils.types import MediaType, SystemConfigKey, RmtMode
 from app.media import Media
 
 
@@ -21,6 +21,8 @@ class Scraper:
     _scraper_flag = False
     _scraper_nfo = {}
     _scraper_pic = {}
+    _rmt_mode = None
+    _temp_path = None
 
     def __init__(self):
         self.media = Media()
@@ -30,6 +32,10 @@ class Scraper:
         if scraper_conf:
             self._scraper_nfo = scraper_conf.get('scraper_nfo') or {}
             self._scraper_pic = scraper_conf.get('scraper_pic') or {}
+        self._rmt_mode = None
+        self._temp_path = os.path.join(Config().get_temp_path(), "scraper")
+        if not os.path.exists(self._temp_path):
+            os.makedirs(self._temp_path)
 
     def folder_scraper(self, path, exclude_path=None, mode=None):
         """
@@ -370,9 +376,8 @@ class Scraper:
         # 保存文件
         self.__save_nfo(doc, os.path.join(out_path, os.path.join(out_path, "%s.nfo" % file_name)))
 
-    @staticmethod
     @retry(RequestException, logger=log)
-    def __save_image(url, out_path, itype='', force=False):
+    def __save_image(self, url, out_path, itype='', force=False):
         """
         下载poster.jpg并保存
         """
@@ -388,9 +393,23 @@ class Scraper:
             log.info(f"【Scraper】正在下载{itype}图片：{url} ...")
             r = RequestUtils().get_res(url=url, raise_exception=True)
             if r:
-                with open(file=image_path,
-                          mode="wb") as img:
-                    img.write(r.content)
+                # 下载到temp目录，远程则先存到temp再远程移动，本地则直接保存
+                if self._rmt_mode in ModuleConf.REMOTE_RMT_MODES:
+                    temp_img = os.path.join(self._temp_path, image_path)
+                    temp_img_dir = os.path.dirname(temp_img)
+                    if not os.path.exists(temp_img_dir):
+                        os.makedirs(temp_img_dir)
+                    with open(file=temp_img, mode="wb") as img:
+                        img.write(r.content)
+                    if self._rmt_mode in [RmtMode.RCLONE, RmtMode.RCLONECOPY]:
+                        SystemUtils.rclone_move(temp_img, image_path)
+                    elif self._rmt_mode in [RmtMode.MINIO, RmtMode.MINIOCOPY]:
+                        SystemUtils.minio_move(temp_img, image_path)
+                    else:
+                        SystemUtils.move(temp_img, image_path)
+                else:
+                    with open(file=image_path, mode="wb") as img:
+                        img.write(r.content)
                 log.info(f"【Scraper】{itype}图片已保存：{image_path}")
             else:
                 log.info(f"【Scraper】{itype}图片下载失败，请检查网络连通性")
@@ -399,12 +418,26 @@ class Scraper:
         except Exception as err:
             ExceptionUtils.exception_traceback(err)
 
-    @staticmethod
-    def __save_nfo(doc, out_file):
+    def __save_nfo(self, doc, out_file):
         log.info("【Scraper】正在保存NFO文件：%s" % out_file)
         xml_str = doc.toprettyxml(indent="  ", encoding="utf-8")
-        with open(out_file, "wb") as xml_file:
-            xml_file.write(xml_str)
+        # 下载到temp目录，远程则先存到temp再远程移动，本地则直接保存
+        if self._rmt_mode in ModuleConf.REMOTE_RMT_MODES:
+            temp_file = os.path.join(self._temp_path, out_file)
+            temp_file_dir = os.path.dirname(temp_file)
+            if not os.path.exists(temp_file_dir):
+                os.makedirs(temp_file_dir)
+            with open(temp_file, "wb") as xml_file:
+                xml_file.write(xml_str)
+            if self._rmt_mode in [RmtMode.RCLONE, RmtMode.RCLONECOPY]:
+                SystemUtils.rclone_move(temp_file, out_file)
+            elif self._rmt_mode in [RmtMode.MINIO, RmtMode.MINIOCOPY]:
+                SystemUtils.minio_move(temp_file, out_file)
+            else:
+                SystemUtils.move(temp_file, out_file)
+        else:
+            with open(out_file, "wb") as xml_file:
+                xml_file.write(xml_str)
         log.info("【Scraper】NFO文件已保存：%s" % out_file)
 
     def gen_scraper_files(self,
@@ -414,7 +447,8 @@ class Scraper:
                           file_ext,
                           force=False,
                           force_nfo=False,
-                          force_pic=False):
+                          force_pic=False,
+                          rmt_mode=None):
         """
         刮削元数据入口
         :param media: 已识别的媒体信息
@@ -424,6 +458,7 @@ class Scraper:
         :param force: 是否强制刮削
         :param force_nfo: 是否强制刮削NFO
         :param force_pic: 是否强制刮削图片
+        :param rmt_mode: 转移方式
         """
         if not force and not self._scraper_flag:
             return
@@ -434,6 +469,8 @@ class Scraper:
             self._scraper_nfo = {}
         if not self._scraper_pic:
             self._scraper_pic = {}
+
+        self._rmt_mode = rmt_mode
 
         try:
             # 电影

--- a/app/sync.py
+++ b/app/sync.py
@@ -91,7 +91,7 @@ class Sync(object):
             log.info(f"【Sync】读取到监控目录：{monpath}，{log_content1}转移方式：{syncmode_enum.value}{log_content2}")
             if not enabled:
                 log.info(f"【Sync】{monpath} 不进行监控和同步：手动关闭")
-            if target_path and not os.path.exists(target_path):
+            if target_path and not os.path.exists(target_path) and syncmode_enum not in ModuleConf.REMOTE_RMT_MODES:
                 log.info(f"【Sync】目的目录不存在，正在创建：{target_path}")
                 os.makedirs(target_path)
             if unknown_path and not os.path.exists(unknown_path):


### PR DESCRIPTION
- 远程转移时（rclone移动复制，minio移动复制）不检查目的目录存在及创建，防止权限问题
- 刮削文件根据转移方式，远程转移时，先存在temp下再远程移动