### PR TITLE
update: 优化主页数据统计显示

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -440,7 +440,10 @@
           }
         },
         legend: {
-          data: ['电影', '电视剧', '动漫']
+          data: ['电影', '电视剧', '动漫'],
+          textStyle: {
+            color: '#206bc4'
+          }
         },
         toolbox: {
           feature: {


### PR DESCRIPTION
# 修改内容

优化黑暗模式下, 主页数据统计部分文字看不清的问题.

# 解决方式

将文字颜色改为与确认键相同.

# 新旧样式比较

## 旧图表

![83c4a5675735dec1f527488cb3a0a80](https://user-images.githubusercontent.com/23419678/235475831-3e9e7a64-4b21-4bed-83de-807387a22e60.png)
![aec7ccf1ef6b1bbb30bd076362e7eb6](https://user-images.githubusercontent.com/23419678/235475845-8203c0d5-ec7c-48ae-b92d-977f2279d444.png)

## 新图表

![062ac6c3f4101770abdd41a2496d935](https://user-images.githubusercontent.com/23419678/235475867-c3570a84-cb0e-457a-865a-efebd2a8274a.png)
![17aebbc08809f22a7a061ce04d30616](https://user-images.githubusercontent.com/23419678/235475883-198e5d2f-eaaf-449b-94b5-40dcf672051e.png)

