### PR TITLE
fix 插件立即运行一次增加3s延迟

### DIFF
--- a/app/plugins/modules/autobackup.py
+++ b/app/plugins/modules/autobackup.py
@@ -1,7 +1,7 @@
 import glob
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytz
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -159,7 +159,8 @@ class AutoBackup(_IPluginModule):
             if self._onlyonce:
                 self.info(f"备份服务启动，立即运行一次")
                 self._scheduler.add_job(self.__backup, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
                 # 关闭一次性开关
                 self._onlyonce = False
                 self.update_config({

--- a/app/plugins/modules/autosignin.py
+++ b/app/plugins/modules/autosignin.py
@@ -217,7 +217,8 @@ class AutoSignIn(_IPluginModule):
             if self._onlyonce:
                 self.info(f"签到服务启动，立即运行一次")
                 self._scheduler.add_job(self.sign_in, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
 
             if self._onlyonce or self._clean:
                 # 关闭一次性开关|清理缓存开关

--- a/app/plugins/modules/cloudflarespeedtest.py
+++ b/app/plugins/modules/cloudflarespeedtest.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from threading import Event
 
@@ -216,7 +216,8 @@ class CloudflareSpeedTest(_IPluginModule):
             if self._onlyonce:
                 self.info(f"Cloudflare CDN优选服务启动，立即运行一次")
                 self._scheduler.add_job(self.__cloudflareSpeedTest, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
                 # 关闭一次性开关
                 self._onlyonce = False
                 self.__update_config()

--- a/app/plugins/modules/cookiecloud.py
+++ b/app/plugins/modules/cookiecloud.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import Event
 
 import pytz
@@ -186,7 +186,8 @@ class CookieCloud(_IPluginModule):
             if self._onlyonce:
                 self.info(f"同步服务启动，立即运行一次")
                 self._scheduler.add_job(self.__cookie_sync, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
                 # 关闭一次性开关
                 self._onlyonce = False
                 self.update_config({

--- a/app/plugins/modules/doubanrank.py
+++ b/app/plugins/modules/doubanrank.py
@@ -1,6 +1,6 @@
 import re
 import xml.dom.minidom
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import Event
 
 import pytz
@@ -98,7 +98,8 @@ class DoubanRank(_IPluginModule):
             if self._onlyonce:
                 self.info(f"订阅服务启动，立即运行一次")
                 self._scheduler.add_job(self.__refresh_rss, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
                 # 关闭一次性开关
                 self._onlyonce = False
                 self.update_config({
@@ -423,7 +424,8 @@ class DoubanRank(_IPluginModule):
                         continue
                     if self._vote and media_info.vote_average \
                             and media_info.vote_average < self._vote:
-                        self.info(f"{media_info.get_title_string()} 评分 {media_info.vote_average} 低于限制 {self._vote}，跳过 ．．．")
+                        self.info(
+                            f"{media_info.get_title_string()} 评分 {media_info.vote_average} 低于限制 {self._vote}，跳过 ．．．")
                         continue
                     # 检查媒体服务器是否存在
                     item_id = self.mediaserver.check_item_exists(mtype=media_info.type,

--- a/app/plugins/modules/doubansync.py
+++ b/app/plugins/modules/doubansync.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import Event, Lock
 from time import sleep
 
@@ -106,7 +106,8 @@ class DoubanSync(_IPluginModule):
             if self._onlyonce:
                 self.info(f"同步服务启动，立即运行一次")
                 self._scheduler.add_job(self.sync, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
                 # 关闭一次性开关
                 self._onlyonce = False
                 self.update_config({
@@ -127,9 +128,9 @@ class DoubanSync(_IPluginModule):
 
     def get_state(self):
         return self._enable \
-            and self._interval \
-            and self._users \
-            and self._types
+               and self._interval \
+               and self._users \
+               and self._types
 
     @staticmethod
     def get_fields():

--- a/app/plugins/modules/iyuuautoseed.py
+++ b/app/plugins/modules/iyuuautoseed.py
@@ -1,6 +1,6 @@
 import re
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import Event
 
 import pytz
@@ -240,7 +240,8 @@ class IYUUAutoSeed(_IPluginModule):
             if self._onlyonce:
                 self.info(f"辅种服务启动，立即运行一次")
                 self._scheduler.add_job(self.auto_seed, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
                 # 关闭一次性开关
                 self._onlyonce = False
             if self._clearcache:

--- a/app/plugins/modules/libraryscraper.py
+++ b/app/plugins/modules/libraryscraper.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import Event
 
 import pytz
@@ -164,7 +164,8 @@ class LibraryScraper(_IPluginModule):
             if self._onlyonce:
                 self.info(f"刮削服务启动，立即运行一次")
                 self._scheduler.add_job(self.__libraryscraper, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
                 # 关闭一次性开关
                 self._onlyonce = False
                 self.update_config({

--- a/app/plugins/modules/movierandom.py
+++ b/app/plugins/modules/movierandom.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import Event
 
 import pytz
@@ -283,7 +283,8 @@ class MovieRandom(_IPluginModule):
             if self._onlyonce:
                 self.info(f"电影随机服务启动，立即运行一次")
                 self._scheduler.add_job(self.__random, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
                 # 关闭一次性开关
                 self._onlyonce = False
                 self.update_config({
@@ -468,7 +469,7 @@ class MovieRandom(_IPluginModule):
 
     def get_state(self):
         return self._enable \
-            and self._cron
+               and self._cron
 
     def stop_service(self):
         """

--- a/app/plugins/modules/torrenttransfer.py
+++ b/app/plugins/modules/torrenttransfer.py
@@ -1,6 +1,6 @@
 import os.path
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import Event
 
 import pytz
@@ -316,7 +316,8 @@ class TorrentTransfer(_IPluginModule):
             if self._onlyonce:
                 self.info(f"移转做种服务启动，立即运行一次")
                 self._scheduler.add_job(self.transfer, 'date',
-                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())))
+                                        run_date=datetime.now(tz=pytz.timezone(Config().get_timezone())) + timedelta(
+                                            seconds=3))
                 # 关闭一次性开关
                 self._onlyonce = False
                 self.update_config({


### PR DESCRIPTION
群晖用户经常选了立即运行一次说不执行，日志如下，不知啥原因耽搁执行了

Run time of job "TorrentTransfer.transfer (trigger: date[2023-05-10 11:52:15 CST], next run at: 2023-05-10 11:52:15 CST)" was missed by 0:00:01.675689